### PR TITLE
IO mode, CategoryType, Testing, & bug fixes

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,10 @@
+[run]
+branch = True
+source = coverage_model
+include = coverage_model/*
+
+[report]
+ignore_errors = True
+
+[html]
+directory = code_coverage_results

--- a/coverage_model/__init__.py
+++ b/coverage_model/__init__.py
@@ -3,7 +3,7 @@ from coverage import SimplexCoverage, SimpleDomainSet, GridDomain, GridShape, CR
 from parameter import ParameterContext, ParameterDictionary
 from parameter_types import ArrayType, BooleanType, CategoryRangeType, CategoryType, ConstantType, CountRangeType, CountType, FunctionType, QuantityRangeType, QuantityType, RecordType, ReferenceType, TextType, TimeRangeType, TimeType, VectorType
 from parameter_values import get_value_class
-from utils import create_guid
+from utils import create_guid, fix_slice
 from numexpr_utils import make_range_expr
 
 _core = ['ParameterContext', 'ParameterDictionary', 'SimplexCoverage', 'SimpleDomainSet',
@@ -13,7 +13,7 @@ _types = ['ArrayType', 'BooleanType', 'CategoryRangeType', 'CategoryType', 'Cons
           'CountRangeType', 'CountType', 'FunctionType', 'QuantityRangeType', 'QuantityType',
           'RecordType', 'ReferenceType', 'TextType', 'TimeRangeType', 'TimeType', 'VectorType', ]
 
-_utils = ['make_range_expr', 'create_guid', 'get_value_class']
+_utils = ['make_range_expr', 'create_guid', 'get_value_class', 'fix_slice']
 
 # Determines the set of things imported by using:  from coverage_model import *
 __all__ = _core + _types + _utils

--- a/coverage_model/basic_types.py
+++ b/coverage_model/basic_types.py
@@ -12,6 +12,10 @@ import numpy as np
 from coverage_model.utils import create_guid, is_valid_constraint
 
 class Dictable(object):
+    """
+    The Dictable class provides dump and load functions backed by overridable _todict and _fromdict functions.
+    It's purpose is to enable custom objects to be converted to/from a composable python dictionary.
+    """
 
     def dump(self):
         """
@@ -166,10 +170,17 @@ class AbstractIdentifiable(AbstractBase):
         return self._identifier
 
 class AbstractStorage(AbstractBase):
+    """
+    Base *Storage class within the Coverage Model
+
+    """
 
     def __init__(self, dtype=None, fill_value=None, **kwargs):
         """
+        Construct a new AbstractStorage object
 
+        @param dtype    The data type for this storage object - currently expected to be the .str of a valid numpy dtype
+        @param fill_value   This value is used to fill 'unassigned' spaces in the storage
         @param **kwargs Additional keyword arguments are copied and the copy is passed up to AbstractBase; see documentation for that class for details
         """
         kwc=kwargs.copy()
@@ -178,12 +189,41 @@ class AbstractStorage(AbstractBase):
         self.fill_value = fill_value
 
     def __getitem__(self, slice_):
+        """
+        Called to implement evaluation of self[slice_].
+
+        Not implemented by the abstract class
+
+        @param slice_  A set of valid constraints - int, [int,], (int,), or slice
+        @return    The value contained by the storage at location slice_
+        @raise NotImplementedError
+        """
         raise NotImplementedError('Not implemented in abstract class')
 
     def __setitem__(self, slice_, value):
+        """
+        Called to implement assignment of self[slice_].
+
+        Not implemented by the abstract class
+
+        @param slice_  A set of valid constraints - int, [int,], (int,), or slice
+        @param value   The value to assign to the storage at location slice_
+        @raise NotImplementedError
+        """
         raise NotImplementedError('Not implemented in abstract class')
 
     def expand(self, arrshp, origin, expansion):
+        """
+        Expands the storage by:
+            inserting <i>arrshp</i> @ <i>origin expansion</i> times
+
+        Not implemented by the abstract class
+
+        @param arrshp   the shape (as a tuple) of the expansion
+        @param origin  the origin of the expansion; determines where arrshp is inserted
+        @param expansion   the number of expansions
+        @raise NotImplementedError
+        """
         raise NotImplementedError('Not implemented in abstract class')
 
     def fill(self, value):

--- a/coverage_model/coverage.py
+++ b/coverage_model/coverage.py
@@ -48,6 +48,7 @@ import os
 #=========================
 # Coverage Objects
 #=========================
+from pyon.util.async import spawn
 
 class AbstractCoverage(AbstractIdentifiable):
     """
@@ -450,8 +451,13 @@ class SimplexCoverage(AbstractCoverage):
             if pc.dom.tdom is not None:
                 pc.dom.tdom = self.temporal_domain.shape.extents
 
-            self._persistence_layer.expand_domain(pc, tdom=self.temporal_domain)
+            self._persistence_layer.expand_domain(pc)
             self._range_value[n].expand_content(VariabilityEnum.TEMPORAL, origin, count)
+
+        # Update the temporal_domain in the master_manager, do NOT flush!!
+        self._persistence_layer.update_domain(tdom=self.temporal_domain, do_flush=False)
+        # Flush the master_manager & parameter_managers in a separate greenlet
+        spawn(self._persistence_layer.flush)
 
     def set_time_values(self, value, tdoa=None):
         """

--- a/coverage_model/coverage.py
+++ b/coverage_model/coverage.py
@@ -70,6 +70,9 @@ class AbstractCoverage(AbstractIdentifiable):
         if not isinstance(cov_obj, AbstractCoverage):
             raise StandardError('cov_obj must be an instance or subclass of AbstractCoverage: object is {0}'.format(type(cov_obj)))
 
+        if not isinstance(cov_obj._persistence_layer, InMemoryPersistenceLayer):
+            raise StandardError('cov_obj must be constructed with the \'in_memory_storage\' flag == True')
+
         with open(file_path, 'w') as f:
             pickle.dump(cov_obj, f, 0 if use_ascii else 2)
 

--- a/coverage_model/parameter.py
+++ b/coverage_model/parameter.py
@@ -85,7 +85,7 @@ class ParameterContext(AbstractIdentifiable):
              'comment',
              'code_reports',]
 
-    def __init__(self, name, param_type=None, axis=None, fill_value=None, variability=None, **kwargs):
+    def __init__(self, name, param_type=None, axis=None, fill_value=None, variability=None, uom=None, **kwargs):
         """
         Construct a new ParameterContext object
 
@@ -131,6 +131,7 @@ class ParameterContext(AbstractIdentifiable):
                 self.param_type = copy.deepcopy(param_context.param_type)
 
             self.axis = axis or param_context.axis
+            self.uom = uom or param_context.uom
             self.fill_value = fill_value or param_context.fill_value
             self.variability = variability or param_context.variability
 
@@ -146,6 +147,7 @@ class ParameterContext(AbstractIdentifiable):
             self.param_type = param_type or QuantityType()
 
             self.axis = axis or None
+            self.uom = uom or None
             if fill_value is not None: # Provided by ParameterType
                 self.fill_value = fill_value
             self.variability = variability or VariabilityEnum.BOTH

--- a/coverage_model/parameter.py
+++ b/coverage_model/parameter.py
@@ -131,7 +131,10 @@ class ParameterContext(AbstractIdentifiable):
                 self.param_type = copy.deepcopy(param_context.param_type)
 
             self.axis = axis or param_context.axis
-            self.uom = uom or param_context.uom
+            if uom is not None:
+                self.uom = uom
+            elif param_context.uom is not None:
+                self.uom = param_context.uom
             self.fill_value = fill_value or param_context.fill_value
             self.variability = variability or param_context.variability
 
@@ -147,7 +150,8 @@ class ParameterContext(AbstractIdentifiable):
             self.param_type = param_type or QuantityType()
 
             self.axis = axis or None
-            self.uom = uom or None
+            if uom is not None:
+                self.uom = uom
             if fill_value is not None: # Provided by ParameterType
                 self.fill_value = fill_value
             self.variability = variability or VariabilityEnum.BOTH

--- a/coverage_model/persistence.py
+++ b/coverage_model/persistence.py
@@ -631,6 +631,8 @@ class PersistedStorage(AbstractStorage):
         @param value:  The value to assign to the storage at location slice_
         @raise: ValueError when brick contains no values for specified slice
         """
+        if self.mode == 'r':
+            raise IOError('PersistenceLayer not open for writing: mode == \'{0}\''.format(self.mode))
 
         if not isinstance(slice_, (list,tuple)):
             slice_ = [slice_]

--- a/coverage_model/persistence.py
+++ b/coverage_model/persistence.py
@@ -764,6 +764,6 @@ class InMemoryPersistenceLayer(object):
         # No Op
         pass
 
-    def close(self):
+    def close(self, force=False, timeout=None):
         # No Op
         pass

--- a/coverage_model/persistence.py
+++ b/coverage_model/persistence.py
@@ -26,15 +26,19 @@ class PersistenceError(Exception):
 class PersistenceLayer(object):
     def __init__(self, root, guid, name=None, tdom=None, sdom=None, bricking_scheme=None, auto_flush_values=True, **kwargs):
         """
-        Constructor for Persistence Layer
-        @param root: Where to save/look for HDF5 files
-        @param guid: CoverageModel GUID
-        @param name: CoverageModel Name
-        @param tdom: Temporal Domain
-        @param sdom: Spatial Domain
+        Constructor for PersistenceLayer
+
+        @param root: The <root> component of the filesystem path for the coverage (/<root>/<guid>)
+        @param guid: The <guid> component of the filesystem path for the coverage (/<root>/<guid>)
+        @param name: CoverageModel's name persisted to the metadata attribute in the master HDF5 file
+        @param tdom: Concrete instance of AbstractDomain for the temporal domain component
+        @param sdom: Concrete instance of AbstractDomain for the spatial domain component
+        @param bricking_scheme: A dictionary containing the brick and chunk sizes
+        @param auto_flush_values: True = Values flushed to HDF5 files automatically, False = Manual
         @param kwargs:
-        @return:
+        @return: None
         """
+
         log.debug('Persistence GUID: %s', guid)
         root = '.' if root is ('' or None) else root
 
@@ -77,11 +81,14 @@ class PersistenceLayer(object):
 
     def calculate_brick_size(self, tD, bricking_scheme):
         """
-        Calculate brick domain size given a target file system brick size (Mbytes) and dtype
-        @param tD:
-        @param bricking_scheme:
+        Calculates and returns the brick and chunk size for each dimension
+        in the total domain based on the bricking scheme
+
+        @param tD: Total domain
+        @param bricking_scheme: A dictionary containing the brick and chunk sizes
         @return:
         """
+
         log.debug('Calculating the size of a brick...')
         log.debug('Bricking scheme: %s', bricking_scheme)
         log.debug('tD: %s', tD)
@@ -92,6 +99,15 @@ class PersistenceLayer(object):
         return bD,tuple(cD)
 
     def init_parameter(self, parameter_context, bricking_scheme):
+        """
+        Initializes a parameter using a ParameterContext object and a bricking
+        scheme for that parameter
+
+        @param parameter_context: ParameterContext object describing the parameter to initialize
+        @param bricking_scheme: A dictionary containing the brick and chunk sizes
+        @return: A PersistedStorage object
+        """
+
         parameter_name = parameter_context.name
 
         self.global_bricking_scheme = bricking_scheme
@@ -144,12 +160,14 @@ class PersistenceLayer(object):
 
     def calculate_extents(self, origin, bD, parameter_name):
         """
-        Calculates the Rtree extents, brick extents and active brick size for the parameter
-        @param origin:
-        @param bD:
-        @param parameter_name:
-        @return:
+        Calculates and returns the Rtree extents, brick extents and active brick size for the parameter
+
+        @param origin: The origin of the brick in index space
+        @param bD: The brick's domain in index space
+        @param parameter_name: The parameter name
+        @return: rtree_extents, tuple(brick_extents), tuple(brick_active_size)
         """
+
         log.debug('origin: %s', origin)
         log.debug('bD: %s', bD)
         log.debug('parameter_name: %s', parameter_name)
@@ -180,6 +198,15 @@ class PersistenceLayer(object):
         return rtree_extents, tuple(brick_extents), tuple(brick_active_size)
 
     def _brick_exists(self, parameter_name, brick_extents):
+        """
+        Checks if a brick exists for a given parameter and extents
+
+        @param parameter_name: The parameter name
+        @param brick_extents: The brick extents
+        @return: Boolean (do_write) = False if found, returns found brick's GUID;
+         otherwise returns True with an empty brick GUID
+        """
+
         # Make sure the brick doesn't already exist if we already have some bricks
         do_write = True
         brick_guid = ''
@@ -196,6 +223,18 @@ class PersistenceLayer(object):
 
     # Write empty HDF5 brick to the filesystem
     def write_brick(self, rtree_extents, brick_extents, brick_active_size, origin, bD, parameter_name):
+        """
+        Creates a virtual brick in the PersistenceLayer by updating the HDF5 master file's
+        brick list, rtree and ExternalLink to where the HDF5 file will be saved in the future (lazy create)
+
+        @param rtree_extents: Total extents of brick's domain in rtree format
+        @param brick_extents: Size of brick
+        @param brick_active_size: Size of brick (same rank as parameter)
+        @param origin: Domain origin offset
+        @param bD: Slice-friendly size of brick's domain
+        @param parameter_name: Parameter name as string
+        @return: N/A
+        """
         pm = self.parameter_metadata[parameter_name]
 
 #        rtree_extents, brick_extents, brick_active_size = self.calculate_extents(origin, bD, parameter_name)
@@ -236,6 +275,16 @@ class PersistenceLayer(object):
 
     # Expand the domain
     def expand_domain(self, parameter_context, tdom=None, sdom=None):
+        """
+        Expands a parameter's total domain based on the requested new temporal and/or spatial domains.
+        Temporal domain expansion is most typical.
+        Number of dimensions may not change for the parameter.
+
+        @param parameter_context: ParameterContext object
+        @param tdom: Requested new temporal domain size
+        @param sdom: Requested new spatial domain size
+        @return: N/A
+        """
         parameter_name = parameter_context.name
         log.debug('Expand %s', parameter_name)
         pm = self.parameter_metadata[parameter_name]
@@ -318,6 +367,12 @@ class PersistenceLayer(object):
 
     # Returns a count of bricks for a parameter
     def parameter_brick_count(self, parameter_name):
+        """
+        Counts and returns the number of bricks in a given parameter's brick list
+
+        @param parameter_name:
+        @return: The number of virtual bricks
+        """
         ret = 0
         if parameter_name in self.parameter_metadata:
             ret = len(self.parameter_metadata[parameter_name].brick_list)
@@ -327,6 +382,11 @@ class PersistenceLayer(object):
         return ret
 
     def has_dirty_values(self):
+        """
+        Checks if the master file values have been modified
+
+        @return: True if master file metadata has been modified
+        """
         for v in self.value_list.itervalues():
             if v.has_dirty_values():
                 return True
@@ -357,11 +417,20 @@ class PersistenceLayer(object):
         self._closed = True
 
 class PersistedStorage(AbstractStorage):
-
+    """
+    A concrete implementation of AbstractStorage utilizing the ParameterManager and brick dispatcher
+    """
     def __init__(self, parameter_manager, brick_dispatcher, dtype=None, fill_value=None, auto_flush=True, **kwargs):
         """
+        Constructor for PersistedStorage
 
-        @param **kwargs Additional keyword arguments are copied and the copy is passed up to AbstractStorage; see documentation for that class for details
+        @param parameter_manager: ParameterManager object for the coverage
+        @param brick_dispatcher: BrickDispatcher object for the coverage
+        @param dtype: Data type (HDF5/numpy) of parameter
+        @param fill_value: HDF5/numpy compatible value based on dtype, returned if no value set within valid extent request
+        @param auto_flush: Saves/flushes data to HDF5 files on every assignment
+        @param kwargs: Additional keyword arguments
+        @return: N/A
         """
         kwc=kwargs.copy()
         AbstractStorage.__init__(self, dtype=dtype, fill_value=fill_value, **kwc)
@@ -402,6 +471,13 @@ class PersistedStorage(AbstractStorage):
 
     # Calculates the bricks from Rtree (brick_tree) using the slice_
     def _bricks_from_slice(self, slice_):
+        """
+        Calculates the a list of bricks from the rtree based on the requested slice
+
+        @param slice_: Requested slice
+        @return: Sorted list of tuples denoting the bricks
+        """
+
         # Make sure we don't modify the global slice_ object
         sl = deepcopy(slice_)
 
@@ -444,6 +520,16 @@ class PersistedStorage(AbstractStorage):
         return ret
 
     def __getitem__(self, slice_):
+        """
+        Called to implement evaluation of self[slice_].
+
+        Not implemented by the abstract class
+
+        @param slice_: A set of valid constraints - int, [int,], (int,), or slice
+        @return: The value contained by the storage at location slice
+        @raise: ValueError when brick contains no values for specified slice
+        """
+
         if not isinstance(slice_, (list,tuple)):
             slice_ = [slice_]
         log.debug('getitem slice_: %s', slice_)
@@ -503,6 +589,16 @@ class PersistedStorage(AbstractStorage):
         return ret_arr
 
     def __setitem__(self, slice_, value):
+        """
+        Called to implement assignment of self[slice_, value].
+
+        Not implemented by the abstract class
+
+        @param slice:  A set of valid constraints - int, [int,], (int,), or slice
+        @param value:  The value to assign to the storage at location slice_
+        @raise: ValueError when brick contains no values for specified slice
+        """
+
         if not isinstance(slice_, (list,tuple)):
             slice_ = [slice_]
         log.debug('setitem slice_: %s', slice_)
@@ -588,6 +684,17 @@ class PersistedStorage(AbstractStorage):
                 self._queue_work(work_key, work_metrics, work)
 
     def _calc_slices(self, slice_, brick_guid, value, val_origin, brick_origin_offset=0):
+        """
+        Calculates and returns the brick_slice, value_slice and brick_origin_offset for a given value and slice for a specific brick
+
+        @param slice_: Requested slice
+        @param brick_guid: GUID of brick
+        @param value: Value to apply to brick
+        @param val_origin: An origin offset within the value's domain
+        @param brick_origin_offset: A resultant offset based on the slice, ie. mid-brick slice start
+        @return: brick_slice, value_slice, brick_origin_offset
+        """
+
         brick_origin, _, brick_size = self.brick_list[brick_guid][1:]
         log.debug('Brick %s:  origin=%s, size=%s', brick_guid, brick_origin, brick_size)
         log.debug('Slice set: %s', slice_)
@@ -693,8 +800,16 @@ class PersistedStorage(AbstractStorage):
                 value_slice = brick_slice
 
         return brick_slice, value_slice, brick_origin_offset
+
     # TODO: Does not support n-dimensional
     def _get_array_shape_from_slice(self, slice_):
+        """
+        Calculates and returns the shape of the slice in each dimension of the total domain
+
+        @param slice_: Requested slice
+        @return: A tuple object denoting the shape of the slice in each dimension of the total domain
+        """
+
         log.debug('Getting array shape for slice_: %s', slice_)
 
         vals = self.brick_list.values()

--- a/coverage_model/persistence_helpers.py
+++ b/coverage_model/persistence_helpers.py
@@ -50,7 +50,7 @@ class BaseManager(object):
             with h5py.File(self.file_path, 'a') as f:
                 for k in list(self._dirty):
                     v = getattr(self, k)
-                    log.trace('FLUSH: key=%s  v=%s', k, v)
+#                    log.debug('FLUSH: key=%s  v=%s', k, v)
                     if isinstance(v, Dictable):
                         prefix='DICTABLE|{0}:{1}|'.format(v.__module__, v.__class__.__name__)
                         value = prefix + pack(v.dump())
@@ -110,25 +110,25 @@ class BaseManager(object):
     def _dohash(self, value, hv=None):
         hv = hv or 0
         if value is None or isinstance(value, (str, unicode, int, long, float, bool)):
-            log.trace('is primitive:  value=%s  hv=%s', value, hv)
+#            log.debug('is primitive:  value=%s  hv=%s', value, hv)
             hv = hash(value) ^ hv
         elif isinstance(value, (list, tuple, set)):
-            log.trace('is list/tuple/set:  value=%s  hv=%s', value, hv)
+#            log.debug('is list/tuple/set:  value=%s  hv=%s', value, hv)
             for x in value:
                 hv = self._dohash(x, hv)
         elif isinstance(value, dict):
-            log.trace('is dict:  value=%s  hv=%s', value, hv)
+#            log.debug('is dict:  value=%s  hv=%s', value, hv)
             for k,v in value.iteritems():
                 hv = self._dohash(k, hv)
                 hv = self._dohash(v, hv)
         elif isinstance(value, object):
-            log.trace('is object:  value=%s  hv=%s', value, hv)
+#            log.debug('is object:  value=%s  hv=%s', value, hv)
             hv = self._dohash(value.__dict__, hv)
 
         return hv
 
     def __setattr__(self, key, value):
-        self.__dict__[key] = value
+        super(BaseManager, self).__setattr__(key, value)
         if not key in self._ignore and not key.startswith('_'):
             self._hmap[key] = self._dohash(value)
             self._dirty.add(key)

--- a/coverage_model/test/examples.py
+++ b/coverage_model/test/examples.py
@@ -6,6 +6,7 @@
 @author Christopher Mueller
 @brief Exemplar functions for creation, manipulation, and basic visualization of coverages
 """
+import random
 
 from ooi.logging import log
 from netCDF4 import Dataset
@@ -402,6 +403,10 @@ def ptypescov(save_coverage=False, in_memory=False):
     cnst_flt_ctxt.uom = 'degree_east'
     pdict.add_context(cnst_flt_ctxt)
 
+    cat = {0:'turkey',1:'duck',2:'chicken',99:'None'}
+    cat_ctxt = ParameterContext('category', param_type=CategoryType(categories=cat), variability=VariabilityEnum.TEMPORAL)
+    pdict.add_context(cat_ctxt)
+
 #    func_ctxt = ParameterContext('function', param_type=FunctionType(QuantityType(value_encoding=np.dtype('float32'))))
 #    func_ctxt.long_name = 'example of a parameter of type FunctionType'
 #    pdict.add_context(func_ctxt)
@@ -439,6 +444,8 @@ def ptypescov(save_coverage=False, in_memory=False):
 
     arrval = []
     recval = []
+    catval = []
+    catkeys = cat.keys()
     letts='abcdefghijklmnopqrstuvwxyz'
     while len(letts) < nt:
         letts += 'abcdefghijklmnopqrstuvwxyz'
@@ -446,8 +453,10 @@ def ptypescov(save_coverage=False, in_memory=False):
         arrval.append(np.random.bytes(np.random.randint(1,20))) # One value (which is a byte string) for each member of the domain
         d = {letts[x]: letts[x:]}
         recval.append(d) # One value (which is a dict) for each member of the domain
+        catval.append(random.choice(catkeys))
     scov.set_parameter_values('array', value=arrval)
     scov.set_parameter_values('record', value=recval)
+    scov.set_parameter_values('category', value=catval)
 
     if in_memory and save_coverage:
         SimplexCoverage.pickle_save(scov, 'test_data/ptypes.cov')

--- a/coverage_model/test/examples.py
+++ b/coverage_model/test/examples.py
@@ -6,6 +6,7 @@
 @author Christopher Mueller
 @brief Exemplar functions for creation, manipulation, and basic visualization of coverages
 """
+from coverage_model.utils import prod
 
 from ooi.logging import log
 from netCDF4 import Dataset
@@ -258,6 +259,43 @@ def samplecov2(save_coverage=False, in_memory=False):
 
     if in_memory and save_coverage:
         SimplexCoverage.pickle_save(scov, 'test_data/sample2.cov')
+
+    return scov
+
+def manyparamcov(save_coverage=False, in_memory=False):
+    # Instantiate a ParameterDictionary
+    pdict = ParameterDictionary()
+
+    # Create a set of ParameterContext objects to define the parameters in the coverage, add each to the ParameterDictionary
+    t_ctxt = ParameterContext('time', param_type=QuantityType(value_encoding=np.dtype('int64')))
+    t_ctxt.axis = AxisTypeEnum.TIME
+    t_ctxt.uom = 'seconds since 01-01-1970'
+    pdict.add_context(t_ctxt)
+
+    # Construct temporal and spatial Coordinate Reference System objects
+    tcrs = CRS([AxisTypeEnum.TIME])
+    scrs = CRS([AxisTypeEnum.LON, AxisTypeEnum.LAT])
+
+    # Construct temporal and spatial Domain objects
+    tdom = GridDomain(GridShape('temporal', [0]), tcrs, MutabilityEnum.EXTENSIBLE) # 1d (timeline)
+    sdom = GridDomain(GridShape('spatial', [0]), scrs, MutabilityEnum.IMMUTABLE) # 0d spatial topology (station/trajectory)
+
+    for x in range(500):
+        pdict.add_context(ParameterContext(str(x), param_type=QuantityType(value_encoding=np.dtype('float32'))))
+
+    # Instantiate the SimplexCoverage providing the ParameterDictionary, spatial Domain and temporal Domain
+    bricking_scheme = {'brick_size':1000,'chunk_size':500}
+    scov = SimplexCoverage('test_data', create_guid(), 'sample coverage_model', pdict, tdom, sdom, in_memory, bricking_scheme=bricking_scheme)
+
+    # Insert some timesteps (automatically expands other arrays)
+#    nt = 1000
+#    scov.insert_timesteps(nt)
+#
+#    # Add data for the parameter
+#    scov.set_parameter_values('time', value=np.arange(nt))
+
+    if in_memory and save_coverage:
+        SimplexCoverage.pickle_save(scov, 'test_data/sample.cov')
 
     return scov
 

--- a/coverage_model/test/perftest.py
+++ b/coverage_model/test/perftest.py
@@ -71,7 +71,7 @@ def _fill(scov, size, limit):
     return insert_timer, expand_timer
 
 # run_perf_fill_test(sizes=[1,5,10,15,20,25], limit=300, brick_size=100, chunk_size=25, dtypes=['int64'])
-def run_perf_fill_test(sizes=[100], limit=86400, brick_size=10000, chunk_size=1000, dtypes=all_dtypes):
+def run_perf_fill_test(sizes=[20000], limit=86400, brick_size=10000, chunk_size=1000, dtypes=all_dtypes):
     t = time.localtime()
     str_time = '{0}{1}{2}{3}{4}'.format(t.tm_year,t.tm_mon,t.tm_mday,t.tm_hour,t.tm_min,t.tm_sec)
     output_file = 'perf_result-{0}.csv'.format(str_time)
@@ -102,6 +102,22 @@ def run_perf_fill_test(sizes=[100], limit=86400, brick_size=10000, chunk_size=10
         print 'Folder Size for dtype ({2}) at location {0}: {1}'.format(scov_dict[s], size_dir(scov_dict[s]), s)
 
     return scov_dict
+
+def run_perf_get_test(root_dir, guid):
+    # Open existing coverage
+    scov = SimplexCoverage(root_dir, guid)
+#    pl = scov._persistence_layer
+
+    param_list = scov.list_parameters()
+
+    start = 0
+    end = 100
+    step = 2
+
+    for param in param_list:
+        arr = scov.get_parameter_values(param, slice(start, end, step))
+
+    return arr
 
 def size_dir(d):
     import os

--- a/coverage_model/test/test_coverage_basics.py
+++ b/coverage_model/test/test_coverage_basics.py
@@ -55,6 +55,23 @@ class TestCoverageModelBasicsInt(IonIntegrationTestCase):
         lcov.close()
         self.assertIsInstance(lcov, SimplexCoverage)
 
+    def test_get_data_after_load(self):
+        # Creates a valid coverage, inserts data and .load coverage back up from the HDF5 files.
+        results =[]
+        scov = self._make_samplecov()
+        self._insert_set_get(scov=scov, timesteps=50, data=np.arange(50), _slice=slice(0,50), param='time')
+        pl = scov._persistence_layer
+        guid = scov.persistence_guid
+        root_path = pl.master_manager.root_dir
+        base_path = root_path.replace(guid,'')
+        scov.close()
+        lcov = SimplexCoverage.load(base_path, guid)
+        ret_data = lcov.get_parameter_values('time', slice(0,50))
+        results.append(np.arange(50).any() == ret_data.any())
+        self.assertTrue(False not in results)
+        lcov.close()
+        self.assertIsInstance(lcov, SimplexCoverage)
+
     def test_load_fails_bad_guid(self):
         # Tests load fails if coverage exists and path is correct but GUID is incorrect
         scov = self._make_samplecov()

--- a/coverage_model/test/test_coverage_basics.py
+++ b/coverage_model/test/test_coverage_basics.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python
+
+"""
+@package coverage_model.test.test_coverage
+@file coverage_model/test/test_coverage.py
+@author Christopher Mueller
+@brief Test cases for the coverage_model module
+"""
+
+from pyon.public import log
+from pyon.util.int_test import IonIntegrationTestCase
+from nose.plugins.attrib import attr
+from mock import patch, Mock
+
+import unittest
+
+@attr('INT', group='cov')
+class TestCoverageModelBasicsInt(IonIntegrationTestCase):
+
+    def setUp(self):
+        pass
+

--- a/coverage_model/test/test_coverage_basics.py
+++ b/coverage_model/test/test_coverage_basics.py
@@ -130,6 +130,25 @@ class TestCoverageModelBasicsInt(IonIntegrationTestCase):
         self.assertIsInstance(cov, SimplexCoverage)
         cov.close()
 
+    def test_coverage_mode_expand_domain(self):
+        scov = self._make_samplecov()
+        self.assertEqual(scov.mode, 'r+')
+        scov.close()
+        rcov = SimplexCoverage.load(self.working_dir, scov.persistence_guid, mode='r')
+        self.assertEqual(rcov.mode, 'r')
+        with self.assertRaises(IOError):
+            rcov.insert_timesteps(10)
+
+    def test_coverage_mode_set_value(self):
+        scov = self._make_samplecov()
+        self.assertEqual(scov.mode, 'r+')
+        scov.insert_timesteps(10)
+        scov.close()
+        rcov = SimplexCoverage.load(self.working_dir, scov.persistence_guid, mode='r')
+        self.assertEqual(rcov.mode, 'r')
+        with self.assertRaises(IOError):
+            rcov._range_value.time[0] = 1
+
     def test_load_succeeds_with_options(self):
         # Tests loading a SimplexCoverage using init parameters
         scov = self._make_samplecov()

--- a/coverage_model/test/test_coverage_basics.py
+++ b/coverage_model/test/test_coverage_basics.py
@@ -22,7 +22,7 @@ class TestCoverageModelBasicsInt(IonIntegrationTestCase):
     def setUp(self):
         # Create temporary working directory for the persisted coverage tests
         self.working_dir = tempfile.mkdtemp()
-    
+
     def tearDown(self):
         # Removes temporary files
         # Comment this out if you need to inspect the HDF5 files.
@@ -553,7 +553,7 @@ class TestCoverageModelBasicsInt(IonIntegrationTestCase):
         self.assertNotEquals(pdict_1,  pdict_4)
         self.assertEquals(pdict_1.compare(pdict_4), {'lat': ['lat'], 'lon': ['lon'], None: [], 'temp': ['temp', 'temp2'], 'time': ['time']})
 
-    def test_pickle_problems(self):
+    def test_pickle_problems_in_memory(self):
         # Tests saving and loading with both successful and unsuccessful test scenarios
         # Instantiate a ParameterDictionary
         pdict = ParameterDictionary()
@@ -575,7 +575,7 @@ class TestCoverageModelBasicsInt(IonIntegrationTestCase):
 
         # Instantiate the SimplexCoverage providing the ParameterDictionary, spatial Domain and temporal Domain
         bricking_scheme = {'brick_size':1000,'chunk_size':500}
-        scov = SimplexCoverage('test_data', create_guid(), 'sample coverage_model', pdict, tdom, sdom, True, bricking_scheme=bricking_scheme)
+        scov = SimplexCoverage('test_data', create_guid(), 'sample coverage_model', pdict, tdom, sdom, bricking_scheme=bricking_scheme, in_memory_storage=True)
 
         # Insert some timesteps (automatically expands other arrays)
         nt = 2000
@@ -880,7 +880,7 @@ class TestCoverageModelBasicsInt(IonIntegrationTestCase):
 
         # Instantiate the SimplexCoverage providing the ParameterDictionary, spatial Domain and temporal Domain
         bricking_scheme = {'brick_size':1000,'chunk_size':500}
-        scov = SimplexCoverage('test_data', create_guid(), 'sample coverage_model', pdict, tdom, sdom, in_memory, bricking_scheme=bricking_scheme)
+        scov = SimplexCoverage('test_data', create_guid(), 'sample coverage_model', pdict, tdom, sdom, in_memory_storage=in_memory, bricking_scheme=bricking_scheme)
 
         # Insert some timesteps (automatically expands other arrays)
         nt = 2000

--- a/coverage_model/test/test_coverage_basics.py
+++ b/coverage_model/test/test_coverage_basics.py
@@ -9,6 +9,13 @@
 
 from pyon.public import log
 from pyon.util.int_test import IonIntegrationTestCase
+import numpy as np
+import time
+from coverage_model.basic_types import AxisTypeEnum, MutabilityEnum, create_guid, VariabilityEnum
+from coverage_model.coverage import CRS, GridDomain, GridShape, SimplexCoverage
+from coverage_model.numexpr_utils import make_range_expr
+from coverage_model.parameter import ParameterDictionary, ParameterContext
+from coverage_model.parameter_types import QuantityType, ConstantType, ArrayType, RecordType
 from nose.plugins.attrib import attr
 from mock import patch, Mock
 
@@ -20,3 +27,331 @@ class TestCoverageModelBasicsInt(IonIntegrationTestCase):
     def setUp(self):
         pass
 
+    def _run_standard_tests(self, scov, timesteps):
+        results = []
+        # Check basic metadata
+        results.append(scov.name == 'sample coverage_model')
+        results.append(scov.num_timesteps == timesteps)
+        results.append(list(scov.temporal_domain.shape.extents) == [timesteps])
+#        log.debug(scov.temporal_domain.shape.extents)
+        req_params = ['conductivity', 'lat', 'lon', 'temp', 'time']
+        params = scov.list_parameters()
+#        log.debug(req_params)
+#        log.debug(params)
+        for param in params:
+            results.append(param in req_params)
+            pc = scov.get_parameter_context(param)
+            results.append(len(pc.dom.identifier) == 36)
+            pc_dom_dict = pc.dom.dump()
+        pdict = scov.parameter_dictionary.dump()
+#        log.debug(results)
+        return (False not in results)
+
+    def _run_data_retrieval_tests(self, scov, timesteps):
+        results = []
+        orig = np.arange(timesteps)
+#        log.debug(orig)
+        params = scov.list.parameters()
+        for param in params:
+            vals = scov.get_parameter_values(param,slice(0,timesteps))
+#            log.debug(vals)
+            results.append((orig == vals).all())
+        return (False not in results)
+
+    def test_samplecov_create(self):
+        res = False
+        tsteps = 0
+        scov = self._make_samplecov()
+        res = self._run_standard_tests(scov, tsteps)
+        tsteps = 10
+        res = self._insert_set_get(scov=scov, timesteps=tsteps, data=np.arange(tsteps), _slice=slice(0,tsteps), param='all')
+        res = self._run_standard_tests(scov, tsteps)
+        prev_tsteps = tsteps
+        tsteps = 35
+        res = self._insert_set_get(scov=scov, timesteps=tsteps, data=np.arange(tsteps)+prev_tsteps, _slice=slice(0,tsteps), param='all')
+        res = self._run_standard_tests(scov, tsteps+prev_tsteps)
+#        res = self._run_data_retrieval_tests(scov, tsteps+prev_tsteps)
+        self.assertTrue(res)
+
+    def test_samplecov_time_one_brick(self):
+        scov = self._make_samplecov()
+        self.assertTrue(self._insert_set_get(scov=scov, timesteps=10, data=np.arange(10), _slice=slice(0,10), param='time'))
+
+    def test_samplecov_allparams_one_brick(self):
+        scov = self._make_samplecov()
+        self.assertTrue(self._insert_set_get(scov=scov, timesteps=10, data=np.arange(10), _slice=slice(0,10), param='all'))
+
+    def test_samplecov_time_five_bricks(self):
+        scov = self._make_samplecov()
+        self.assertTrue(self._insert_set_get(scov=scov, timesteps=50, data=np.arange(50), _slice=slice(0,50), param='time'))
+
+    def test_samplecov_allparams_five_bricks(self):
+        scov = self._make_samplecov()
+        self.assertTrue(self._insert_set_get(scov=scov, timesteps=50, data=np.arange(50), _slice=slice(0,50), param='all'))
+
+    def test_samplecov_time_one_brick_strided(self):
+        scov = self._make_samplecov()
+        self.assertTrue(self._insert_set_get(scov=scov, timesteps=10, data=np.arange(10), _slice=slice(0,10,2), param='time'))
+
+    def test_samplecov_time_five_bricks_strided(self):
+        scov = self._make_samplecov()
+        self.assertTrue(self._insert_set_get(scov=scov, timesteps=50, data=np.arange(50), _slice=slice(0,50,5), param='time'))
+
+    def test_ptypescov_create(self):
+        scov = self._make_ptypescov()
+        self.assertTrue(scov.name == 'sample coverage_model')
+
+    def test_ptypescov_load_data(self):
+        ptypes_cov = self._make_ptypescov()
+        ptypes_cov_loaded = self._load_ptypescov(ptypes_cov)
+        self.assertTrue(ptypes_cov_loaded.temporal_domain.shape.extents == (10,))
+
+    def test_ptypescov_get_values(self):
+        results = []
+        ptypes_cov = self._make_ptypescov()
+        ptypes_cov_loaded = self._load_ptypescov(ptypes_cov)
+        time.sleep(5)
+        results.append((ptypes_cov_loaded._range_value.quantity_time[:] == np.arange(10)).all())
+        results.append(ptypes_cov_loaded._range_value.const_int[0] == 45)
+        total_errors = sum([1 for v in results if v == False])
+        self.assertTrue(total_errors==0)
+
+    def test_nospatial_create(self):
+        scov = self._make_nospatialcov()
+        self.assertTrue(scov.name == 'sample coverage_model')
+
+    def test_emptysamplecov_create(self):
+        scov = self._make_emptysamplecov()
+        self.assertTrue(scov.name == 'empty sample coverage_model')
+
+    def _insert_set_get(self, scov, timesteps, data, _slice, param='all'):
+        data = data[_slice]
+        ret = []
+
+        scov.insert_timesteps(timesteps)
+        param_list = []
+        if param == 'all':
+            param_list = scov.list_parameters()
+        else:
+            param_list.append(param)
+
+        for param in param_list:
+            scov.set_parameter_values(param, data, _slice)
+            # Sleep to make sure data gets saved to disk by the dispatcher
+            time.sleep(5)
+            ret = scov.get_parameter_values(param, _slice)
+        return (ret == data).all()
+
+    def _load_ptypescov(self, scov):
+        # Insert some timesteps (automatically expands other arrays)
+        scov.insert_timesteps(10)
+
+        # Add data for each parameter
+        scov.set_parameter_values('quantity_time', value=np.arange(10))
+        scov.set_parameter_values('const_int', value=45.32) # Set a constant directly, with incorrect data type (fixed under the hood)
+        scov.set_parameter_values('const_float', value=make_range_expr(-71.11)) # Set with a properly formed constant expression
+        scov.set_parameter_values('quantity', value=np.random.random_sample(10)*(26-23)+23)
+
+        #    # Setting three range expressions such that indices 0-2 == 10, 3-7 == 15 and >=8 == 20
+        #    scov.set_parameter_values('function', value=make_range_expr(10, 0, 3, min_incl=True, max_incl=False, else_val=-999.9))
+        #    scov.set_parameter_values('function', value=make_range_expr(15, 3, 8, min_incl=True, max_incl=False, else_val=-999.9))
+        #    scov.set_parameter_values('function', value=make_range_expr(20, 8, min_incl=True, max_incl=False, else_val=-999.9))
+
+        arrval = []
+        recval = []
+        letts='abcdefghij'
+        for x in xrange(scov.num_timesteps):
+            arrval.append(np.random.bytes(np.random.randint(1,20))) # One value (which is a byte string) for each member of the domain
+            d = {letts[x]: letts[x:]}
+            recval.append(d) # One value (which is a dict) for each member of the domain
+        scov.set_parameter_values('array', value=arrval)
+        scov.set_parameter_values('record', value=recval)
+
+        return scov
+
+    def _make_ptypescov(save_coverage=False, in_memory=False):
+        # Construct temporal and spatial Coordinate Reference System objects
+        tcrs = CRS([AxisTypeEnum.TIME])
+        scrs = CRS([AxisTypeEnum.LON, AxisTypeEnum.LAT])
+
+        # Construct temporal and spatial Domain objects
+        tdom = GridDomain(GridShape('temporal', [0]), tcrs, MutabilityEnum.EXTENSIBLE) # 1d (timeline)
+        sdom = GridDomain(GridShape('spatial', [0]), scrs, MutabilityEnum.IMMUTABLE) # 0d spatial topology (station/trajectory)
+
+        # Instantiate a ParameterDictionary
+        pdict = ParameterDictionary()
+
+        # Create a set of ParameterContext objects to define the parameters in the coverage, add each to the ParameterDictionary
+        quant_t_ctxt = ParameterContext('quantity_time', param_type=QuantityType(value_encoding=np.dtype('int64')), variability=VariabilityEnum.TEMPORAL)
+        quant_t_ctxt.reference_frame = AxisTypeEnum.TIME
+        quant_t_ctxt.uom = 'seconds since 01-01-1970'
+        pdict.add_context(quant_t_ctxt)
+
+        cnst_int_ctxt = ParameterContext('const_int', param_type=ConstantType(QuantityType(value_encoding=np.dtype('int32'))), variability=VariabilityEnum.NONE)
+        cnst_int_ctxt.long_name = 'example of a parameter of type ConstantType, base_type int32'
+        cnst_int_ctxt.reference_frame = AxisTypeEnum.LAT
+        cnst_int_ctxt.uom = 'degree_north'
+        pdict.add_context(cnst_int_ctxt)
+
+        cnst_flt_ctxt = ParameterContext('const_float', param_type=ConstantType(), variability=VariabilityEnum.NONE)
+        cnst_flt_ctxt.long_name = 'example of a parameter of type QuantityType, base_type float (default)'
+        cnst_flt_ctxt.reference_frame = AxisTypeEnum.LON
+        cnst_flt_ctxt.uom = 'degree_east'
+        pdict.add_context(cnst_flt_ctxt)
+
+        #    func_ctxt = ParameterContext('function', param_type=FunctionType(QuantityType(value_encoding=np.dtype('float32'))))
+        #    func_ctxt.long_name = 'example of a parameter of type FunctionType'
+        #    pdict.add_context(func_ctxt)
+
+        quant_ctxt = ParameterContext('quantity', param_type=QuantityType(value_encoding=np.dtype('float32')))
+        quant_ctxt.long_name = 'example of a parameter of type QuantityType'
+        quant_ctxt.uom = 'degree_Celsius'
+        pdict.add_context(quant_ctxt)
+
+        arr_ctxt = ParameterContext('array', param_type=ArrayType())
+        arr_ctxt.long_name = 'example of a parameter of type ArrayType, will be filled with variable-length \'byte-string\' data'
+        pdict.add_context(arr_ctxt)
+
+        rec_ctxt = ParameterContext('record', param_type=RecordType())
+        rec_ctxt.long_name = 'example of a parameter of type RecordType, will be filled with dictionaries'
+        pdict.add_context(rec_ctxt)
+
+        # Instantiate the SimplexCoverage providing the ParameterDictionary, spatial Domain and temporal Domain
+        scov = SimplexCoverage('test_data', create_guid(), 'sample coverage_model', pdict, tdom, sdom, in_memory)
+
+        return scov
+
+    def _make_samplecov(self, save_coverage=False, in_memory=False):
+        # Instantiate a ParameterDictionary
+        pdict = ParameterDictionary()
+
+        # Create a set of ParameterContext objects to define the parameters in the coverage, add each to the ParameterDictionary
+        t_ctxt = ParameterContext('time', param_type=QuantityType(value_encoding=np.dtype('int64')))
+        t_ctxt.reference_frame = AxisTypeEnum.TIME
+        t_ctxt.uom = 'seconds since 01-01-1970'
+        pdict.add_context(t_ctxt)
+
+        lat_ctxt = ParameterContext('lat', param_type=QuantityType(value_encoding=np.dtype('float32')))
+        lat_ctxt.reference_frame = AxisTypeEnum.LAT
+        lat_ctxt.uom = 'degree_north'
+        pdict.add_context(lat_ctxt)
+
+        lon_ctxt = ParameterContext('lon', param_type=QuantityType(value_encoding=np.dtype('float32')))
+        lon_ctxt.reference_frame = AxisTypeEnum.LON
+        lon_ctxt.uom = 'degree_east'
+        pdict.add_context(lon_ctxt)
+
+        temp_ctxt = ParameterContext('temp', param_type=QuantityType(value_encoding=np.dtype('float32')))
+        temp_ctxt.uom = 'degree_Celsius'
+        pdict.add_context(temp_ctxt)
+
+        cond_ctxt = ParameterContext('conductivity', param_type=QuantityType(value_encoding=np.dtype('float32')))
+        cond_ctxt.uom = 'unknown'
+        pdict.add_context(cond_ctxt)
+
+        # Construct temporal and spatial Coordinate Reference System objects
+        tcrs = CRS([AxisTypeEnum.TIME])
+        scrs = CRS([AxisTypeEnum.LON, AxisTypeEnum.LAT])
+
+        # Construct temporal and spatial Domain objects
+        tdom = GridDomain(GridShape('temporal', [0]), tcrs, MutabilityEnum.EXTENSIBLE) # 1d (timeline)
+        sdom = GridDomain(GridShape('spatial', [0]), scrs, MutabilityEnum.IMMUTABLE) # 0d spatial topology (station/trajectory)
+
+        # Instantiate the SimplexCoverage providing the ParameterDictionary, spatial Domain and temporal Domain
+        scov = SimplexCoverage('test_data', create_guid(), 'sample coverage_model', pdict, tdom, sdom, in_memory)
+        return scov
+
+    def _make_nospatialcov(save_coverage=False, in_memory=False):
+        # Construct temporal and spatial Coordinate Reference System objects
+        tcrs = CRS([AxisTypeEnum.TIME])
+
+        # Construct temporal and spatial Domain objects
+        tdom = GridDomain(GridShape('temporal', [0]), tcrs, MutabilityEnum.EXTENSIBLE) # 1d (timeline)
+
+        # Instantiate a ParameterDictionary
+        pdict = ParameterDictionary()
+
+        # Create a set of ParameterContext objects to define the parameters in the coverage, add each to the ParameterDictionary
+        t_ctxt = ParameterContext('quantity_time', param_type=QuantityType(value_encoding=np.dtype('int64')), variability=VariabilityEnum.TEMPORAL)
+        t_ctxt.reference_frame = AxisTypeEnum.TIME
+        t_ctxt.uom = 'seconds since 01-01-1970'
+        pdict.add_context(t_ctxt)
+
+        quant_ctxt = ParameterContext('quantity', param_type=QuantityType(value_encoding=np.dtype('float32')))
+        quant_ctxt.long_name = 'example of a parameter of type QuantityType'
+        quant_ctxt.uom = 'degree_Celsius'
+        pdict.add_context(quant_ctxt)
+
+        const_ctxt = ParameterContext('constant', param_type=ConstantType())
+        const_ctxt.long_name = 'example of a parameter of type ConstantType'
+        pdict.add_context(const_ctxt)
+
+        arr_ctxt = ParameterContext('array', param_type=ArrayType())
+        arr_ctxt.long_name = 'example of a parameter of type ArrayType with base_type ndarray (resolves to \'object\')'
+        pdict.add_context(arr_ctxt)
+
+        arr2_ctxt = ParameterContext('array2', param_type=ArrayType())
+        arr2_ctxt.long_name = 'example of a parameter of type ArrayType with base_type object'
+        pdict.add_context(arr2_ctxt)
+
+        # Instantiate the SimplexCoverage providing the ParameterDictionary, spatial Domain and temporal Domain
+        scov = SimplexCoverage('test_data', create_guid(), 'sample coverage_model', pdict, temporal_domain=tdom, in_memory_storage=in_memory)
+
+        # Insert some timesteps (automatically expands other arrays)
+        scov.insert_timesteps(10)
+
+        # Add data for each parameter
+        scov.set_parameter_values('quantity_time', value=np.arange(10))
+        scov.set_parameter_values('quantity', value=np.random.random_sample(10)*(26-23)+23)
+        scov.set_parameter_values('constant', value=20)
+
+        arrval = []
+        arr2val = []
+        for x in xrange(scov.num_timesteps): # One value (which IS an array) for each member of the domain
+            arrval.append(np.random.bytes(np.random.randint(1,20)))
+            arr2val.append(np.random.random_sample(np.random.randint(1,10)))
+        scov.set_parameter_values('array', value=arrval)
+        scov.set_parameter_values('array2', value=arr2val)
+
+        return scov
+
+    def _make_emptysamplecov(save_coverage=False, in_memory=False):
+        # Instantiate a ParameterDictionary
+        pdict = ParameterDictionary()
+
+        # Create a set of ParameterContext objects to define the parameters in the coverage, add each to the ParameterDictionary
+        t_ctxt = ParameterContext('time', param_type=QuantityType(value_encoding=np.dtype('int64')))
+        t_ctxt.reference_frame = AxisTypeEnum.TIME
+        t_ctxt.uom = 'seconds since 01-01-1970'
+        pdict.add_context(t_ctxt)
+
+        lat_ctxt = ParameterContext('lat', param_type=QuantityType(value_encoding=np.dtype('float32')))
+        lat_ctxt.reference_frame = AxisTypeEnum.LAT
+        lat_ctxt.uom = 'degree_north'
+        pdict.add_context(lat_ctxt)
+
+        lon_ctxt = ParameterContext('lon', param_type=QuantityType(value_encoding=np.dtype('float32')))
+        lon_ctxt.reference_frame = AxisTypeEnum.LON
+        lon_ctxt.uom = 'degree_east'
+        pdict.add_context(lon_ctxt)
+
+        temp_ctxt = ParameterContext('temp', param_type=QuantityType(value_encoding=np.dtype('float32')))
+        temp_ctxt.uom = 'degree_Celsius'
+        pdict.add_context(temp_ctxt)
+
+        cond_ctxt = ParameterContext('conductivity', param_type=QuantityType(value_encoding=np.dtype('float32')))
+        cond_ctxt.uom = 'unknown'
+        pdict.add_context(cond_ctxt)
+
+        # Construct temporal and spatial Coordinate Reference System objects
+        tcrs = CRS([AxisTypeEnum.TIME])
+        scrs = CRS([AxisTypeEnum.LON, AxisTypeEnum.LAT])
+
+        # Construct temporal and spatial Domain objects
+        tdom = GridDomain(GridShape('temporal', [0]), tcrs, MutabilityEnum.EXTENSIBLE) # 1d (timeline)
+        sdom = GridDomain(GridShape('spatial', [0]), scrs, MutabilityEnum.IMMUTABLE) # 0d spatial topology (station/trajectory)
+
+        # Instantiate the SimplexCoverage providing the ParameterDictionary, spatial Domain and temporal Domain
+        scov = SimplexCoverage('test_data', create_guid(), 'empty sample coverage_model', pdict, tdom, sdom, in_memory)
+
+        return scov

--- a/coverage_model/test/test_numexpr_utils.py
+++ b/coverage_model/test/test_numexpr_utils.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python
+
+"""
+@package 
+@file test_numexpr_utils
+@author Christopher Mueller
+@brief 
+"""
+from pyon.util.unit_test import PyonTestCase
+from coverage_model import *
+from coverage_model.numexpr_utils import nest_wheres, denest_wheres, is_nested_where, is_well_formed_nested, is_well_formed_where
+from nose.plugins.attrib import attr
+
+@attr('UNIT',group='cov')
+class TestNumexprUtilsUnit(PyonTestCase):
+
+    def test_make_range_expr(self):
+
+        s='c*10'
+        expr = make_range_expr(10)
+        self.assertEqual(s, expr)
+
+        s = 'where(x > 99, 8, -999)'
+        expr = make_range_expr(8, min=99, else_val=-999)
+        self.assertEqual(s, expr)
+
+        s = 'where(x >= 99, 8, -999)'
+        expr = make_range_expr(8, min=99, min_incl=True, else_val=-999)
+        self.assertEqual(s, expr)
+
+        s = 'where(x < 10, 100, -999)'
+        expr = make_range_expr(100, max=10, max_incl=False, else_val=-999)
+        self.assertEqual(s, expr)
+
+        s = 'where(x <= 10, 100, -999)'
+        expr = make_range_expr(100, max=10, else_val=-999)
+        self.assertEqual(s, expr)
+
+        s = 'where((x > 0) & (x <= 100), 55, 100)'
+        expr = make_range_expr(55, min=0, max=100, else_val=100)
+        self.assertEqual(s, expr)
+
+        s = 'where((x >= 0) & (x <= 100), 55, 100)'
+        expr = make_range_expr(55, min=0, max=100, min_incl=True, else_val=100)
+        self.assertEqual(s, expr)
+
+        s = 'where((x >= 0) & (x < 100), 55, 100)'
+        expr = make_range_expr(55, min=0, max=100, min_incl=True, max_incl=False, else_val=100)
+        self.assertEqual(s, expr)
+
+        s = 'where((x > 0) & (x < 100), 55, 100)'
+        expr = make_range_expr(55, min=0, max=100, min_incl=False, max_incl=False, else_val=100)
+        self.assertEqual(s, expr)
+
+        self.assertTrue(is_well_formed_where(expr))
+        self.assertFalse(is_nested_where(expr))
+        self.assertFalse(is_well_formed_nested(expr))
+
+    def test_nest_wheres(self):
+        expr1 = make_range_expr(val=-888, max=0, max_incl=False)
+        expr2 = make_range_expr(val=111, min=0, min_incl=True, max=10, max_incl=False)
+        expr3 = make_range_expr(val=222, max=20, max_incl=False, else_val=-999)
+
+        # Tests that expressions are nested properly
+        expr = nest_wheres(expr1, expr2, expr3)
+        s = 'where(x < 0, -888, where((x >= 0) & (x < 10), 111, where(x < 20, 222, -999)))'
+        self.assertEqual(s, expr)
+        self.assertTrue(is_nested_where(expr))
+        self.assertTrue(is_well_formed_nested(expr))
+
+        # Tests that invalid expressions are thrown out
+        expr = nest_wheres('should not be included', expr1, expr2, 'where(also not included)', expr3)
+        self.assertEqual(s, expr)
+        self.assertTrue(is_nested_where(expr))
+        self.assertTrue(is_well_formed_where(expr))
+        self.assertTrue(is_well_formed_nested(expr))
+
+        s = 'where(x < 0, -888, where((x >= 0) & (x < 10), 111, where(x < 20, 222, -999)])'
+        self.assertFalse(is_well_formed_nested(s))
+        s = 'where(x < 0, -888, where((x >= 0) & (x < 10), 111, where(bad)))'
+        self.assertFalse(is_well_formed_nested(s))
+
+        self.assertRaises(IndexError, nest_wheres, 'bob')
+
+    def test_denest_wheres(self):
+        expr1 = make_range_expr(val=-888, max=0, max_incl=False)
+        expr2 = make_range_expr(val=111, min=0, min_incl=True, max=10, max_incl=False)
+        expr3 = make_range_expr(val=222, max=20, max_incl=False, else_val=-9999)
+
+        expr = nest_wheres(expr1, expr2, expr3)
+
+        exprs = denest_wheres(expr)
+        self.assertIsInstance(exprs, list)
+
+        e1,e2,e3 = exprs[:]
+        self.assertEqual(expr1, e1)
+        self.assertEqual(expr2, e2)
+        self.assertEqual(expr3, e3)
+
+        self.assertRaises(ValueError, denest_wheres, 'bob')
+
+
+

--- a/coverage_model/test/test_utils.py
+++ b/coverage_model/test/test_utils.py
@@ -28,12 +28,16 @@ class TestUtilsUnit(PyonTestCase):
         self.assertEqual(r, utils.prod([a,b,c]))
 
     def test_create_guid(self):
-        import re
-        guid_match = r'^\w{8}-\w{4}-\w{4}-\w{4}-\w{12}'
         guid = utils.create_guid()
-        self.assertIsInstance(guid, str)
-        self.assertIsNotNone(re.match(guid_match, guid))
 
+        # Ensure the guid is a str
+        self.assertIsInstance(guid, str)
+
+        # Make sure it's properly formatted - this also tests is_guid
+        self.assertTrue(utils.is_guid(guid))
+
+        # Test that is_guid fails when appropriate
+        self.assertFalse(utils.is_guid(guid[:-1]))
 
     def test_is_valid_constraint_passes(self):
         sl = 1

--- a/coverage_model/test/test_utils.py
+++ b/coverage_model/test/test_utils.py
@@ -1,0 +1,298 @@
+#!/usr/bin/env python
+
+"""
+@package 
+@file test_utils.py
+@author Christopher Mueller
+@brief 
+"""
+from pyon.util.unit_test import PyonTestCase
+from nose.plugins.attrib import attr
+import coverage_model.utils as utils
+
+@attr('UNIT',group='cov')
+class TestUtilsUnit(PyonTestCase):
+
+    def setUp(self):
+        pass
+
+    def tearDown(self):
+        pass
+
+    def test_prod(self):
+        a = 3
+        b = 4
+        c = 6
+        r = a * b * c
+
+        self.assertEqual(r, utils.prod([a,b,c]))
+
+    def test_create_guid(self):
+        import re
+        guid_match = r'^\w{8}-\w{4}-\w{4}-\w{4}-\w{12}'
+        guid = utils.create_guid()
+        self.assertIsInstance(guid, str)
+        self.assertIsNotNone(re.match(guid_match, guid))
+
+
+    def test_is_valid_constraint_passes(self):
+        sl = 1
+        self.assertTrue(utils.is_valid_constraint(sl))
+
+        sl = [0,1,2]
+        self.assertTrue(utils.is_valid_constraint(sl))
+
+        sl = (0,1,2)
+        self.assertTrue(utils.is_valid_constraint(sl))
+
+        sl = slice(None,None,None)
+        self.assertTrue(utils.is_valid_constraint(sl))
+
+    def test_is_valid_constraint_fails(self):
+        sl = 'bob'
+        self.assertFalse(utils.is_valid_constraint(sl))
+
+        sl = 43.2
+        self.assertFalse(utils.is_valid_constraint(sl))
+
+    def test_is_valid_constraint_nested_passes(self):
+        sl = [[1,2,3]]
+        self.assertTrue(utils.is_valid_constraint(sl))
+
+        sl = ((1,2,3))
+        self.assertTrue(utils.is_valid_constraint(sl))
+
+        sl = [slice(1,2,3),slice(None,None,None)]
+        self.assertTrue(utils.is_valid_constraint(sl))
+
+        sl = [slice(1,2,3), 2, 3]
+        self.assertTrue(utils.is_valid_constraint(sl))
+
+        sl = [1, slice(2,3,4), [1,3,5]]
+        self.assertTrue(utils.is_valid_constraint(sl))
+
+    def test_is_valid_constraint_nested_fails(self):
+        sl = ['bob', 1, 4]
+        self.assertFalse(utils.is_valid_constraint(sl))
+
+        sl = [1, slice(2,3,4), 10.4]
+        self.assertFalse(utils.is_valid_constraint(sl))
+
+
+    def test__raise_index_error_int(self):
+        size = 10
+        dim = 0
+
+        # Negative index
+        self.assertRaises(IndexError, utils._raise_index_error_int, -1, size, dim)
+
+        # Index == size
+        self.assertRaises(IndexError, utils._raise_index_error_int, size, size, dim)
+
+        # Index > size
+        self.assertRaises(IndexError, utils._raise_index_error_int, size+1, size, dim)
+
+        # Non failure
+        utils._raise_index_error_int(1,size,dim)
+
+    def test__raise_index_error_list(self):
+        size = 10
+        dim = 0
+
+        # List with duplicate indices
+        self.assertRaises(IndexError, utils._raise_index_error_list, [1,1], size, dim)
+
+        # List with non-increasing indices
+        self.assertRaises(IndexError, utils._raise_index_error_list, [2,1], size, dim)
+
+        # List with an index == size
+        self.assertRaises(IndexError, utils._raise_index_error_list, [1,size], size, dim)
+
+        # List with an index > size
+        self.assertRaises(IndexError, utils._raise_index_error_list, [1,size+1], size, dim)
+
+        #### Passes ####
+        utils._raise_index_error_list([1,2,8],size,dim)
+
+    def test__raise_index_error_slice(self):
+        size = 10
+        dim = 0
+
+        self.assertRaises(IndexError, utils._raise_index_error_slice, slice(10, 2, None), size, dim)
+        self.assertRaises(IndexError, utils._raise_index_error_slice, slice(2, 2, None), size, dim)
+        self.assertRaises(IndexError, utils._raise_index_error_slice, slice(-1, 9, None), size, dim)
+        self.assertRaises(IndexError, utils._raise_index_error_slice, slice(None, 13, None), size, dim)
+        self.assertRaises(IndexError, utils._raise_index_error_slice, slice(-1, None, None), size, dim)
+        self.assertRaises(IndexError, utils._raise_index_error_slice, slice(None, -1, None), size, dim)
+        self.assertRaises(IndexError, utils._raise_index_error_slice, slice(None, 0, None), size, dim)
+
+        #### Passes ####
+        utils._raise_index_error_slice(slice(None,None,None),size,dim)
+        utils._raise_index_error_slice(slice(0,None,None),size,dim)
+        utils._raise_index_error_slice(slice(None,5,None),size,dim)
+        utils._raise_index_error_slice(slice(2,8,None),size,dim)
+
+    def test_fix_slice(self):
+        shp = (50,)
+
+        # Initial 'is_valid_constraint' catches bad stuff
+        self.assertRaises(SystemError, utils.fix_slice, 'bob', shp)
+
+        # Tuples are list-ified
+        sl = utils.fix_slice((20,), shp)
+
+        # Down-ranking (slice with more dims than shp)
+        shp = (50,)
+        sl = utils.fix_slice([5,23], shp)
+        self.assertEqual(sl, (5,))
+
+        # Up-ranking (slice with fewer dims than shp)
+        shp = (50,10,)
+        sl = utils.fix_slice(5, shp)
+        self.assertEqual(sl, (5, slice(None, None, None)))
+
+    def test_fix_slice_with_int(self):
+        shp = (50,)
+
+        # Verify int is tupled
+        sl = utils.fix_slice(7, shp)
+        self.assertEqual(sl, (7,))
+
+        shp = (50,20)
+
+        # Verify list of ints are tupled
+        sl = utils.fix_slice([5,8], shp)
+        self.assertEqual(sl, (5,8,))
+
+        shp = (50,)
+
+        #### Passes ####
+        # Index
+        sl = utils.fix_slice(0, shp)
+        self.assertEqual(sl, (0,))
+
+        # Negative index
+        sl = utils.fix_slice(-4, shp)
+        self.assertEqual(sl, (46,))
+
+        #### Failures ####
+        # Index > size
+        self.assertRaises(IndexError, utils.fix_slice, 52, shp)
+
+        # Negative index > size (after adjustment, index is -2)
+        self.assertRaises(IndexError, utils.fix_slice, -52, shp)
+
+    def test_fix_slice_with_list(self):
+        shp = (50,)
+
+        # Verify list is tupled
+        sl = utils.fix_slice([[7,9]], shp)
+        self.assertEqual(sl, ([7,9],))
+
+        shp = (50,20)
+
+        # Verify list of lists are tupled
+        sl = utils.fix_slice([[5,8],[1,3]], shp)
+        self.assertEqual(sl, ([5,8],[1,3]))
+
+        shp = (50,)
+
+        #### Passes ####
+        # List of indices
+        sl = utils.fix_slice([[5, 14, 36]], shp)
+        self.assertEqual(sl, ([5, 14, 36],))
+
+        # List with some negative indices
+        sl = utils.fix_slice([[5, -36, 23]], shp)
+        self.assertEqual(sl, ([5, 14, 23],))
+
+        # List of all negative indices
+        sl = utils.fix_slice([[-44, -32, -5]], shp)
+        self.assertEqual(sl, ([6, 18, 45],))
+
+        #### Failures ####
+        # List of indices in non-increasing order
+        self.assertRaises(IndexError, utils.fix_slice, [[20, 14, 36]], shp)
+
+        # List of negative indices in non-increasing order (after adjustment, list is [45, 30, 5]
+        self.assertRaises(IndexError, utils.fix_slice, [[-5, -20, -45]], shp)
+
+    def test_fix_slice_with_slice(self):
+        shp = (50,)
+
+        # Verify slice is tupled
+        sl = utils.fix_slice(slice(None, None, None), shp)
+        self.assertEqual(sl, (slice(None, None, None),))
+
+        shp = (50,20)
+
+        # Verify list of slices are tupled
+        sl = utils.fix_slice([slice(None, None, None), slice(None, None, None)], shp)
+        self.assertEqual(sl, (slice(None, None, None), slice(None, None, None),))
+
+        shp = (50,)
+
+        #### Passes ####
+        # Slice with all None
+        sl = utils.fix_slice(slice(None, None, None), shp)
+        self.assertEqual(sl, (slice(None, None, None),))
+
+        # Slice with start=None & stop=positive
+        sl = utils.fix_slice(slice(None, 30, None), shp)
+        self.assertEqual(sl, (slice(None, 30, None),))
+
+        # Slice with start=positive & stop=None
+        sl = utils.fix_slice(slice(10, None, None), shp)
+        self.assertEqual(sl, (slice(10, None, None),))
+
+        # Slice with start=negative & stop=None
+        sl = utils.fix_slice(slice(-10, None, None), shp)
+        self.assertEqual(sl, (slice(40, None, None),))
+
+        # Slice with start=negative & stop=negative
+        sl = utils.fix_slice(slice(-10, -5, None), shp)
+        self.assertEqual(sl, (slice(40, 45, None),))
+
+        # Slice with start=None & stop=negative
+        sl = utils.fix_slice(slice(None, -18, None), shp)
+        self.assertEqual(sl, (slice(None, 32, None),))
+
+        #### Failures ####
+        # Slice with start > stop
+        self.assertRaises(IndexError, utils.fix_slice, slice(30, 2, None), shp)
+
+        # Slice with start == stop
+        self.assertRaises(IndexError, utils.fix_slice, slice(18, 18, None), shp)
+
+        # Slice with start=None & stop > size
+        self.assertRaises(IndexError, utils.fix_slice, slice(None, 52, None), shp)
+
+        # Slice with start > size & stop=None
+        self.assertRaises(IndexError, utils.fix_slice, slice(53, None, None), shp)
+
+        # Slice with start < 0 & stop=None (after adjustment, -52 => -2)
+        self.assertRaises(IndexError, utils.fix_slice, slice(-52, None, None), shp)
+
+        # Slice with start=None & stop=0
+        self.assertRaises(IndexError, utils.fix_slice, slice(None, 0, None), shp)
+
+        # Slice with start=None & stop < 0 (after adjustment, -52 => -2)
+        self.assertRaises(IndexError, utils.fix_slice, slice(None, -52, None), shp)
+
+        # Slice with start=negative & stop=negative with start > stop
+        self.assertRaises(IndexError, utils.fix_slice, slice(-2, -10, None), shp)
+
+        #### Stepping ####
+        # Slice with step != None
+        sl = utils.fix_slice(slice(4, 43, 6), shp)
+        self.assertEqual(sl, (slice(4, 43, 6),))
+        
+        # Slice with negative step - reverses start/stop
+        sl = utils.fix_slice(slice(10, 2, -2), shp)
+        self.assertEqual(sl, (slice(2, 10, 2),))
+
+        # Slice with all negatives (start, stop, step)
+        sl = utils.fix_slice(slice(-3, -22, -5), shp)
+        self.assertEqual(sl, (slice(28, 47, 5),))
+
+        

--- a/coverage_model/utils.py
+++ b/coverage_model/utils.py
@@ -9,6 +9,7 @@
 
 import numpy as np
 import uuid
+import re
 
 def create_guid():
     """
@@ -16,6 +17,10 @@ def create_guid():
     """
     # guids seem to be more readable if they are UPPERCASE
     return str(uuid.uuid4()).upper()
+
+def is_guid(str_val):
+    guid_match = r'^\w{8}-\w{4}-\w{4}-\w{4}-\w{12}'
+    return re.match(guid_match, str_val) is not None
 
 def prod(lst):
     import operator

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,5 @@
+[nosetests]
+cover-package=coverage_model
+cover-html=1
+cover-html-dir=code_coverage_results
+cover-erase=1


### PR DESCRIPTION
Merges the following enhancements, additions, and bug fixes:
- Adds CategoryType parameter type - essentially an "enum" parameter type that enables definition of a custom set of code values and associated meanings.  Allows the codes (typically an integer) to be transported/stored instead of a much bulkier "meaning"
- Adds 'mode' flag to Coverage model - enables the user to specify the standard python file 'modes' ('r', 'w', 'a', & 'r+').  When in 'r' mode, none of the messaging layer is activated thereby reducing overhead and improving overall performance
- Improvements to performance of 'SimplexCoverage.insert_timesteps' call - order of magnitude improvement in function return time; enables Ingestion worker to realize a 5 fold improvement in message throughput
- Adds test suite for coverage model
  *\* Includes both UNIT and "INT" tests, the latter being tests that utilize both the Coverage Model and Persistence Layer - NO Ion service calls
- Bug fixes based on findings from lead-up and presentation of IOC demonstration
