### PR TITLE
Replay alignment

### DIFF
--- a/coverage_model/coverage.py
+++ b/coverage_model/coverage.py
@@ -455,7 +455,7 @@ class SimplexCoverage(AbstractCoverage):
         lst.sort()
         return lst
 
-    def insert_timesteps(self, count, origin=None):
+    def insert_timesteps(self, count, origin=None, oob=True):
         """
         Insert count # of timesteps beginning at the origin
 
@@ -464,6 +464,7 @@ class SimplexCoverage(AbstractCoverage):
 
         @param count    The number of timesteps to insert
         @param origin   The starting location, from which to begin the insertion
+        @param oob      Out of band operations, True will use greenlets, False will be in-band.
         """
         if self.closed:
             raise IOError('I/O operation on closed file')
@@ -494,7 +495,10 @@ class SimplexCoverage(AbstractCoverage):
         # Update the temporal_domain in the master_manager, do NOT flush!!
         self._persistence_layer.update_domain(tdom=self.temporal_domain, do_flush=False)
         # Flush the master_manager & parameter_managers in a separate greenlet
-        spawn(self._persistence_layer.flush)
+        if oob:
+            spawn(self._persistence_layer.flush)
+        else:
+            self._persistence_layer.flush()
 
     def set_time_values(self, value, tdoa=None):
         """

--- a/coverage_model/utils.py
+++ b/coverage_model/utils.py
@@ -168,3 +168,31 @@ def fix_slice(slice_, shape):
 
     # Finally, make it a tuple
     return tuple(slice_)
+
+def slice_len(slice_, shape):
+    '''
+    Returns a list of sizes of for each dimension
+    @param slice_       A slice, integer or list of indices
+    @param shape        The shape of the data
+    '''
+    fixed_slice = fix_slice(slice_, shape)
+
+    slice_lengths = []
+
+    for s,shape in zip(fixed_slice, shape):
+        if isinstance(s,slice):
+            start, stop, stride = s.indices(shape)
+            arr_len = (stop - start)/stride
+        elif isinstance(s, list):
+            arr_len = len(s)
+        elif isinstance(s, int):
+            arr_len = 1
+        else:
+            raise TypeError('Unsupported slice method') # TODO: Better error message
+        
+        slice_lengths.append(arr_len)
+
+    return tuple(slice_lengths)  
+
+
+


### PR DESCRIPTION
Two commits to help align replay data.
- Adds utility for determining the effective length of a slice
- Adds support for `insert_timesteps` to be out of band.
