### PR TITLE
Locks msgpack-python to 0.1.13

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,7 @@ setup(  name = 'coverage-model',
         'pydot==1.0.28',
         'networkx==1.7',
         'pyparsing==1.5.6',
+        'msgpack-python==0.1.13',
 #        'scipy==0.10.1',
     ],
 )


### PR DESCRIPTION
There is a really weird bug with coverage and a newer version of msgpack, this PR locks in the msgpack version.
