### PR TITLE
Adds parameter_bounds to persisted info

### DIFF
--- a/coverage_model/persistence.py
+++ b/coverage_model/persistence.py
@@ -47,7 +47,7 @@ class PersistenceLayer(object):
         log.debug('Persistence GUID: %s', guid)
         root = '.' if root is ('' or None) else root
 
-        self.master_manager = MasterManager(root, guid, name=name, tdom=tdom, sdom=sdom, global_bricking_scheme=bricking_scheme)
+        self.master_manager = MasterManager(root, guid, name=name, tdom=tdom, sdom=sdom, global_bricking_scheme=bricking_scheme, parameter_bounds=None)
 
         self.mode = mode
         if not hasattr(self.master_manager, 'auto_flush_values'):
@@ -90,6 +90,15 @@ class PersistenceLayer(object):
             setattr(self.master_manager, key, value)
         else:
             super(PersistenceLayer, self).__setattr__(key, value)
+
+    def update_parameter_bounds(self, parameter_name, bounds):
+        dmin, dmax = bounds
+        if parameter_name in self.parameter_bounds:
+            pmin, pmax = self.parameter_bounds[parameter_name]
+            dmin = min(dmin, pmin)
+            dmax = max(dmax, pmax)
+        self.parameter_bounds[parameter_name] = (dmin, dmax)
+        self.master_manager.flush()
 
     # CBM TODO: This needs to be improved greatly - should callback all the way to the Application layer as a "failure handler"
     def write_failure_callback(self, message, work):

--- a/coverage_model/persistence_helpers.py
+++ b/coverage_model/persistence_helpers.py
@@ -120,6 +120,8 @@ class MasterManager(BaseManager):
     def __init__(self, root_dir, guid, **kwargs):
         BaseManager.__init__(self, root_dir=os.path.join(root_dir,guid), file_name='{0}_master.hdf5'.format(guid), **kwargs)
         self.guid = guid
+        if self.parameter_bounds is None:
+            self.parameter_bounds = {}
 
         # Add attributes that should NEVER be flushed
         self._ignore.update(['param_groups', 'guid', 'file_path', 'root_dir'])


### PR DESCRIPTION
Adds handling for storage/retrieval of parameter data bounds so they do not need to be calculated at the time of the request.  Bounds are updated as data is added to a parameter and stored in the persistence layer for rapid retrieval across coverage loads.
