### PR TITLE
Bounds update

### DIFF
--- a/coverage_model/coverage.py
+++ b/coverage_model/coverage.py
@@ -275,6 +275,10 @@ class SimplexCoverage(AbstractCoverage):
                     self._range_dictionary.add_context(pc)
                     s = PersistedStorage(md, self._persistence_layer.brick_dispatcher, dtype=pc.param_type.storage_encoding, fill_value=pc.param_type.fill_value, mode=self.mode, inline_data_writes=inline_data_writes, auto_flush=auto_flush_values)
                     self._range_value[parameter_name] = get_value_class(param_type=pc.param_type, domain_set=pc.dom, storage=s)
+                    if parameter_name in self._persistence_layer.parameter_bounds:
+                        bmin, bmax = self._persistence_layer.parameter_bounds[parameter_name]
+                        self._range_value[parameter_name]._min = bmin
+                        self._range_value[parameter_name]._max = bmax
 
             if name is None or parameter_dictionary is None:
                 # This appears to be a load
@@ -596,7 +600,8 @@ class SimplexCoverage(AbstractCoverage):
         log.debug('Setting slice: %s', slice_)
 
         self._range_value[param_name][slice_] = value
-        self._update_parameter_bounds(param_name, value)
+        # Update parameter bounds in the persistence layer
+        self._persistence_layer.update_parameter_bounds(param_name, self._range_value[param_name].bounds)
 
     def get_parameter_values(self, param_name, tdoa=None, sdoa=None, return_value=None):
         """
@@ -720,10 +725,6 @@ class SimplexCoverage(AbstractCoverage):
 
         return params
 
-    def _update_parameter_bounds(self, parameter_name, values):
-        bnds = self._calc_data_bounds(parameter_name, {parameter_name: np.atleast_1d(values)})
-        self._persistence_layer.update_parameter_bounds(parameter_name, bnds)
-
     def get_data_bounds(self, parameter_name=None):
         """
         Returns the bounds (min, max) for the parameter(s) indicated by <i>parameter_name</i>
@@ -741,39 +742,10 @@ class SimplexCoverage(AbstractCoverage):
 
         ret = {}
         for pn in self.__parameter_name_arg_to_params(parameter_name):
-            if pn in self._persistence_layer.parameter_bounds:
-                ret[pn] = self._persistence_layer.parameter_bounds[pn]
-            else:
-                ret[pn] = self._calc_data_bounds(pn, {pn: self._range_value})
+            ret[pn] = self._range_value[pn].bounds
 
         if len(ret) == 1:
             ret = ret.values()[0]
-
-        return ret
-
-    def _calc_data_bounds(self, parameter_name=None, values_dict=None):
-        """
-        Returns the bounds (min, max) for the parameter indicated by <i>parameter_name</i>
-
-        @param parameter_name   A string parameter name; may be an iterable of such members
-        @param values_dict  A dict of the form values_dict[param_name] = values; values should be >= 1d
-        """
-        if values_dict is None:
-            raise ValueError('\'values_dict\' cannot be None!')
-
-        from coverage_model import QuantityType, ConstantType
-        if parameter_name == self.temporal_parameter_name: # Make assumption that temporal is monotonically increasing!!
-            ret = (values_dict[parameter_name][0], values_dict[parameter_name][-1])
-        else:
-            ctxt = self._range_dictionary.get_context(parameter_name)
-            fv = ctxt.fill_value
-            if isinstance(ctxt.param_type, QuantityType) or isinstance(ctxt.param_type, ConstantType):
-                varr = np.ma.masked_equal(values_dict[parameter_name][:], fv, copy=False)
-                r = (varr.min(), varr.max())
-                ret = tuple([fv if isinstance(x, np.ma.core.MaskedConstant) else x for x in r])
-            else:
-                # CBM TODO: Sort out if this is an appropriate way to deal with non-numeric types
-                ret = (fv, fv)
 
         return ret
 

--- a/coverage_model/parameter_values.py
+++ b/coverage_model/parameter_values.py
@@ -14,14 +14,17 @@ from coverage_model import utils
 import numpy as np
 import numexpr as ne
 
+
 def get_value_class(param_type, domain_set, **kwargs):
     module = __import__(param_type._value_module, fromlist=[param_type._value_class])
     classobj = getattr(module, param_type._value_class)
     return classobj(parameter_type=param_type, domain_set=domain_set, **kwargs)
 
+
 #=========================
 # Abstract Parameter Value Objects
 #=========================
+
 
 class AbstractParameterValue(AbstractBase):
     """
@@ -37,10 +40,23 @@ class AbstractParameterValue(AbstractBase):
         self.parameter_type = parameter_type
         self.domain_set = domain_set
         self._storage = storage if storage is not None else InMemoryStorage(dtype=self.parameter_type.storage_encoding, fill_value=self.parameter_type.fill_value)
+        self._min = self._max = self.fill_value
 
     @property
     def shape(self):
         return self.domain_set.total_extents
+
+    @property
+    def bounds(self):
+        return self.min, self.max
+
+    @property
+    def min(self):
+        return self._min
+
+    @property
+    def max(self):
+        return self._max
 
     @property
     def storage(self):
@@ -53,6 +69,10 @@ class AbstractParameterValue(AbstractBase):
     @property
     def value_encoding(self):
         return self.parameter_type.value_encoding
+
+    @property
+    def fill_value(self):
+        return self.parameter_type.fill_value
 
     def expand_content(self, domain, origin, expansion):
         if domain == VariabilityEnum.TEMPORAL: # Temporal
@@ -72,6 +92,25 @@ class AbstractParameterValue(AbstractBase):
 
         self._storage[slice_] = value
 
+        self._update_min_max(value)
+
+    def _update_min_max(self, value):
+
+        # TODO: There is a flaw here when OVERWRITING:
+        # overwritten values may still appear to be a min/max value as
+        # recalculation of the full array does not occur...
+        if np.dtype(self.value_encoding).kind != 'S':  # No min/max for strings
+            v = np.atleast_1d(value)
+            # All values are fill_values, leave what we have!
+            if (v == self.fill_value).all():
+                return
+            # Mask fill_value so it's not included in the calculation
+            v = np.ma.masked_equal(np.atleast_1d(value), self.fill_value, copy=False)
+            # Update min
+            self._min = min(v.min(), self._min) if self._min != self.fill_value else v.min()
+            # Update max
+            self._max = max(v.max(), self._max) if self._min != self.fill_value else v.max()
+
     def __len__(self):
         # I don't think this is correct - should be the length of the total available set of values, not the length of storage...
 #        return len(self._storage)
@@ -79,6 +118,7 @@ class AbstractParameterValue(AbstractBase):
 
     # def __str__(self):
     #     return str(self.content)
+
 
 class AbstractSimplexParameterValue(AbstractParameterValue):
     """
@@ -105,9 +145,16 @@ class AbstractComplexParameterValue(AbstractParameterValue):
         kwc=kwargs.copy()
         AbstractParameterValue.__init__(self, parameter_type, domain_set, storage, **kwc)
 
+    def _update_min_max(self, value):
+        # No-op - Must override in concrete class to make functional
+        # By default, these value types present fill_value for min & max
+        pass
+
+
 #=========================
 # Concrete Parameter Value Objects
 #=========================
+
 
 class NumericValue(AbstractSimplexParameterValue):
 
@@ -119,6 +166,7 @@ class NumericValue(AbstractSimplexParameterValue):
         kwc=kwargs.copy()
         AbstractSimplexParameterValue.__init__(self, parameter_type, domain_set, storage, **kwc)
         self._storage.expand(self.shape, 0, self.shape[0])
+
 
 class BooleanValue(AbstractSimplexParameterValue):
 
@@ -136,6 +184,8 @@ class BooleanValue(AbstractSimplexParameterValue):
 
         if self.parameter_type.is_valid_value(value):
             self._storage[slice_] = np.asanyarray(value, dtype='bool')
+            self._update_min_max(np.asanyarray(value, dtype='int8'))
+
 
 class FunctionValue(AbstractComplexParameterValue):
     # CBM TODO: There are 2 'classes' of Function - those that operate against an INDEX, and those that operate against a VALUE
@@ -178,6 +228,7 @@ class FunctionValue(AbstractComplexParameterValue):
             else:
                 self._storage[0].append(value)
 
+
 class ParameterFunctionValue(AbstractSimplexParameterValue):
 
     def __init__(self, parameter_type, domain_set, storage=None, **kwargs):
@@ -201,6 +252,11 @@ class ParameterFunctionValue(AbstractSimplexParameterValue):
         # No op, storage is not used
         pass
 
+    def _update_min_max(self, value):
+        # TODO: Can possibly do something here?  Only if memoized?
+        # No-op - What's the min/max for this value class?
+        pass
+
     def __getitem__(self, slice_):
         if self._memoized_values is not None:
             return self._memoized_values
@@ -221,6 +277,7 @@ class ParameterFunctionValue(AbstractSimplexParameterValue):
         self._memoized_values = value
 #        raise ValueError('Values cannot be set against ParameterFunctionValues!')
 
+
 class ConstantValue(AbstractComplexParameterValue):
 
     def __init__(self, parameter_type, domain_set, storage=None, **kwargs):
@@ -239,6 +296,10 @@ class ConstantValue(AbstractComplexParameterValue):
     def expand_content(self, domain, origin, expansion):
         # No op storage is always 1 - appropriate domain applied during retrieval of data
         pass
+
+    def _update_min_max(self, value):
+        self._min = value
+        self._max = value
 
     def __getitem__(self, slice_):
         slice_ = utils.fix_slice(slice_, self.shape)
@@ -261,6 +322,9 @@ class ConstantValue(AbstractComplexParameterValue):
             if np.dtype(self.value_encoding).kind == 'S': # If we're dealing with a str
                 value = str(value) # Ensure the value is a str!!
             self._storage[0] = value
+
+            self._update_min_max(value)
+
 
 class ConstantRangeValue(AbstractComplexParameterValue):
 
@@ -296,6 +360,10 @@ class ConstantRangeValue(AbstractComplexParameterValue):
         # No op storage is always 1 - appropriate domain applied during retrieval of data
         pass
 
+    def _update_min_max(self, value):
+        self._min = value
+        self._max = value
+
     def __getitem__(self, slice_):
         slice_ = utils.fix_slice(slice_, self.shape)
 
@@ -315,6 +383,9 @@ class ConstantRangeValue(AbstractComplexParameterValue):
             # We already know it's either a list or tuple, that it's length is >= 2, and that both of
             # the first two values are of the correct type...so...
             self._storage[0] = str(tuple(value[:2]))
+
+            self._update_min_max(self.content)
+
 
 class CategoryValue(AbstractComplexParameterValue):
 
@@ -355,6 +426,7 @@ class CategoryValue(AbstractComplexParameterValue):
             except KeyError, ke:
                 raise ValueError('Invalid category specified: \'{0}\''.format(ke.message))
 
+
 class RecordValue(AbstractComplexParameterValue):
 
     def __init__(self, parameter_type, domain_set, storage=None, **kwargs):
@@ -366,6 +438,7 @@ class RecordValue(AbstractComplexParameterValue):
         AbstractComplexParameterValue.__init__(self, parameter_type, domain_set, storage, **kwc)
         self._storage.expand(self.shape, 0, self.shape[0])
 
+
 class VectorValue(AbstractComplexParameterValue):
 
     def __init__(self, parameter_type, domain_set, storage=None, **kwargs):
@@ -376,6 +449,7 @@ class VectorValue(AbstractComplexParameterValue):
         kwc=kwargs.copy()
         AbstractComplexParameterValue.__init__(self, parameter_type, domain_set, storage, **kwc)
         self._storage.expand(self.shape, 0, self.shape[0])
+
 
 class ArrayValue(AbstractComplexParameterValue):
 

--- a/coverage_model/persistence.py
+++ b/coverage_model/persistence.py
@@ -922,6 +922,8 @@ class PersistedStorage(AbstractStorage):
 
 class InMemoryPersistenceLayer(object):
 
+    parameter_bounds = {}
+
     def expand_domain(self, *args, **kwargs):
         # No Op - storage expanded by *Value classes
         pass
@@ -932,6 +934,14 @@ class InMemoryPersistenceLayer(object):
     def has_dirty_values(self):
         # Never has dirty values
         return False
+
+    def update_parameter_bounds(self, parameter_name, bounds):
+        dmin, dmax = bounds
+        if parameter_name in self.parameter_bounds:
+            pmin, pmax = self.parameter_bounds[parameter_name]
+            dmin = min(dmin, pmin)
+            dmax = max(dmax, pmax)
+        self.parameter_bounds[parameter_name] = (dmin, dmax)
 
     def get_dirty_values_async_result(self):
         from gevent.event import AsyncResult

--- a/coverage_model/persistence.py
+++ b/coverage_model/persistence.py
@@ -47,7 +47,7 @@ class PersistenceLayer(object):
         log.debug('Persistence GUID: %s', guid)
         root = '.' if root is ('' or None) else root
 
-        self.master_manager = MasterManager(root, guid, name=name, tdom=tdom, sdom=sdom, global_bricking_scheme=bricking_scheme)
+        self.master_manager = MasterManager(root, guid, name=name, tdom=tdom, sdom=sdom, global_bricking_scheme=bricking_scheme, parameter_bounds=None)
 
         self.mode = mode
         if not hasattr(self.master_manager, 'auto_flush_values'):
@@ -90,6 +90,15 @@ class PersistenceLayer(object):
             setattr(self.master_manager, key, value)
         else:
             super(PersistenceLayer, self).__setattr__(key, value)
+
+    def update_parameter_bounds(self, parameter_name, bounds):
+        dmin, dmax = bounds
+        if parameter_name in self.parameter_bounds:
+            pmin, pmax = self.parameter_bounds[parameter_name]
+            dmin = min(dmin, pmin)
+            dmax = max(dmax, pmax)
+        self.parameter_bounds[parameter_name] = (dmin, dmax)
+        self.master_manager.flush()
 
     # CBM TODO: This needs to be improved greatly - should callback all the way to the Application layer as a "failure handler"
     def write_failure_callback(self, message, work):

--- a/coverage_model/persistence_helpers.py
+++ b/coverage_model/persistence_helpers.py
@@ -120,6 +120,8 @@ class MasterManager(BaseManager):
     def __init__(self, root_dir, guid, **kwargs):
         BaseManager.__init__(self, root_dir=os.path.join(root_dir,guid), file_name='{0}_master.hdf5'.format(guid), **kwargs)
         self.guid = guid
+        if self.parameter_bounds is None:
+            self.parameter_bounds = {}
 
         # Add attributes that should NEVER be flushed
         self._ignore.update(['param_groups', 'guid', 'file_path', 'root_dir'])

--- a/coverage_model/test/examples.py
+++ b/coverage_model/test/examples.py
@@ -484,7 +484,7 @@ def ptypescov(save_coverage=False, in_memory=False, inline_data_writes=True, mak
     cnst_rng_int_ctxt.long_name = 'example of a parameter of type ConstantRangeType, base_type int16'
     pdict.add_context(cnst_rng_int_ctxt)
 
-    func = NumexprFunction(expression='q*10', param_map={'q':'quantity'})
+    func = NumexprFunction('func', expression='q*10', arg_list=['q'], param_map={'q':'quantity'})
     pfunc_ctxt = ParameterContext('parameter_function', param_type=ParameterFunctionType(function=func), variability=VariabilityEnum.TEMPORAL)
     pfunc_ctxt.long_name = 'example of a parameter of type ParameterFunctionType'
     pdict.add_context(pfunc_ctxt)


### PR DESCRIPTION
Refactors the way data bounds are handled by the coverage model.  Min/Max values are now handled by the individual *Value classes which reduces complexity in higher layers of the coverage model.  Min/Max are also persisted to eliminate the need to recalculate after a coverage load.
