### PR TITLE
Refactor hdf metadata

### DIFF
--- a/coverage_model/__init__.py
+++ b/coverage_model/__init__.py
@@ -1,5 +1,5 @@
 from basic_types import AxisTypeEnum, MutabilityEnum, VariabilityEnum
-from coverage import SimplexCoverage, SimpleDomainSet, GridDomain, GridShape, CRS
+from coverage import SimplexCoverage, ViewCoverage, SimpleDomainSet, GridDomain, GridShape, CRS
 from coverage_model.parameter_functions import PythonFunction, NumexprFunction
 from parameter import ParameterContext, ParameterDictionary, ParameterFunctionValidator
 from parameter_types import ArrayType, BooleanType, CategoryRangeType, CategoryType, ConstantType, CountRangeType, CountType, FunctionType, QuantityRangeType, QuantityType, RecordType, ReferenceType, TextType, TimeRangeType, TimeType, VectorType, ConstantRangeType, ParameterFunctionType
@@ -9,7 +9,7 @@ from utils import create_guid, fix_slice
 from numexpr_utils import make_range_expr
 from coverage_model.base_test_cases import CoverageModelUnitTestCase, CoverageModelIntTestCase
 
-_core = ['ParameterContext', 'ParameterDictionary', 'ParameterFunctionValidator', 'SimplexCoverage', 'SimpleDomainSet',
+_core = ['ParameterContext', 'ParameterDictionary', 'ParameterFunctionValidator', 'SimplexCoverage', 'ViewCoverage', 'SimpleDomainSet',
          'GridDomain', 'GridShape', 'CRS', 'AxisTypeEnum', 'MutabilityEnum', 'VariabilityEnum']
 
 _types = ['ArrayType', 'BooleanType', 'CategoryRangeType', 'CategoryType', 'ConstantType',

--- a/coverage_model/__init__.py
+++ b/coverage_model/__init__.py
@@ -1,20 +1,24 @@
 from basic_types import AxisTypeEnum, MutabilityEnum, VariabilityEnum
-from coverage import SimplexCoverage, ViewCoverage, SimpleDomainSet, GridDomain, GridShape, CRS
+from coverage import SimplexCoverage, ViewCoverage, ComplexCoverage, ComplexCoverageType, SimpleDomainSet, GridDomain, \
+    GridShape, CRS
 from coverage_model.parameter_functions import PythonFunction, NumexprFunction
 from parameter import ParameterContext, ParameterDictionary, ParameterFunctionValidator
-from parameter_types import ArrayType, BooleanType, CategoryRangeType, CategoryType, ConstantType, CountRangeType, CountType, FunctionType, QuantityRangeType, QuantityType, RecordType, ReferenceType, TextType, TimeRangeType, TimeType, VectorType, ConstantRangeType, ParameterFunctionType
+from parameter_types import ArrayType, BooleanType, CategoryRangeType, CategoryType, ConstantType, CountRangeType, \
+    CountType, FunctionType, QuantityRangeType, QuantityType, RecordType, ReferenceType, TextType, TimeRangeType, \
+    TimeType, VectorType, ConstantRangeType, ParameterFunctionType
 from parameter_values import get_value_class
 from coverage_model import utils
 from utils import create_guid, fix_slice
 from numexpr_utils import make_range_expr
 from coverage_model.base_test_cases import CoverageModelUnitTestCase, CoverageModelIntTestCase
 
-_core = ['ParameterContext', 'ParameterDictionary', 'ParameterFunctionValidator', 'SimplexCoverage', 'ViewCoverage', 'SimpleDomainSet',
-         'GridDomain', 'GridShape', 'CRS', 'AxisTypeEnum', 'MutabilityEnum', 'VariabilityEnum']
+_core = ['ParameterContext', 'ParameterDictionary', 'ParameterFunctionValidator', 'SimplexCoverage', 'ViewCoverage',
+         'ComplexCoverage', 'ComplexCoverageType', 'SimpleDomainSet', 'GridDomain', 'GridShape', 'CRS', 'AxisTypeEnum',
+         'MutabilityEnum', 'VariabilityEnum']
 
-_types = ['ArrayType', 'BooleanType', 'CategoryRangeType', 'CategoryType', 'ConstantType',
-          'CountRangeType', 'CountType', 'FunctionType', 'QuantityRangeType', 'QuantityType',
-          'RecordType', 'ReferenceType', 'TextType', 'TimeRangeType', 'TimeType', 'VectorType', 'ConstantRangeType', 'ParameterFunctionType']
+_types = ['ArrayType', 'BooleanType', 'CategoryRangeType', 'CategoryType', 'ConstantType', 'CountRangeType',
+          'CountType', 'FunctionType', 'QuantityRangeType', 'QuantityType', 'RecordType', 'ReferenceType', 'TextType',
+          'TimeRangeType', 'TimeType', 'VectorType', 'ConstantRangeType', 'ParameterFunctionType']
 
 _functions = ['NumexprFunction', 'PythonFunction']
 

--- a/coverage_model/base_test_cases.py
+++ b/coverage_model/base_test_cases.py
@@ -8,6 +8,7 @@
 """
 
 from unittest import TestCase
+import os, shutil, tempfile
 
 
 class CoverageModelUnitTestCase(TestCase):
@@ -21,8 +22,20 @@ class CoverageModelUnitTestCase(TestCase):
 
 class CoverageModelIntTestCase(TestCase):
 
+    working_dir = os.path.join(tempfile.gettempdir(), 'cov_mdl_tests')
+
     # Prevent test docstring from printing - uses test name instead
     # @see
     # http://www.saltycrane.com/blog/2012/07/how-prevent-nose-unittest-using-docstring-when-verbosity-2/
     def shortDescription(self):
         return None
+
+    @classmethod
+    def setUpClass(cls):
+        os.mkdir(cls.working_dir)
+
+    @classmethod
+    def tearDownClass(cls):
+        # Removes temporary files
+        # Comment this out if you need to inspect the HDF5 files.
+        shutil.rmtree(cls.working_dir)

--- a/coverage_model/coverage.py
+++ b/coverage_model/coverage.py
@@ -342,7 +342,7 @@ class AbstractCoverage(AbstractIdentifiable):
         if self.value_caching:
             # Make slice_ fully expressed such that there are no "None" entries - this lets us ignore domain growth
             slk = utils.express_slice(slice_, total_shape)
-            key=(param_name, utils.hash_any(slk))
+            key = (param_name, utils.hash_any(slk))
             try:
                 return_value = self._value_cache.pop(key)
             #                print 'Vals from cache for \'%s\'' % param_name

--- a/coverage_model/coverage.py
+++ b/coverage_model/coverage.py
@@ -1064,6 +1064,8 @@ class SimplexCoverage(AbstractCoverage):
                 # Must be in 'a' for a new coverage
                 self.mode = 'a'
 
+                insert_ts = 0
+
                 if not isinstance(name, basestring):
                     raise TypeError('\'name\' must be of type basestring')
                 self.name = name
@@ -1071,6 +1073,8 @@ class SimplexCoverage(AbstractCoverage):
                     self.temporal_domain = GridDomain(GridShape('temporal',[0]), CRS.standard_temporal(), MutabilityEnum.EXTENSIBLE)
                 elif isinstance(temporal_domain, AbstractDomain):
                     self.temporal_domain = deepcopy(temporal_domain)
+                    insert_ts = self.temporal_domain.shape.extents[0]
+                    self.temporal_domain.shape.extents = (0,) + tuple(self.temporal_domain.shape.extents[1:])
                 else:
                     raise TypeError('\'temporal_domain\' must be an instance of AbstractDomain')
 
@@ -1095,6 +1099,9 @@ class SimplexCoverage(AbstractCoverage):
 
                 for o, pc in parameter_dictionary.itervalues():
                     self.append_parameter(pc)
+
+                if insert_ts != 0:
+                    self.insert_timesteps(insert_ts)
         except:
             self._closed = True
             raise

--- a/coverage_model/coverage.py
+++ b/coverage_model/coverage.py
@@ -1022,12 +1022,13 @@ class SimplexCoverage(AbstractCoverage):
                 from coverage_model.persistence import PersistedStorage
                 for parameter_name in self._persistence_layer.parameter_metadata.keys():
                     md = self._persistence_layer.parameter_metadata[parameter_name]
+                    mm = self._persistence_layer.master_manager
                     pc = md.parameter_context
                     if hasattr(pc, '_pval_callback'):
                         pc._pval_callback = self.get_parameter_values
                         pc._pctxt_callback = self.get_parameter_context
                     self._range_dictionary.add_context(pc)
-                    s = PersistedStorage(md, self._persistence_layer.brick_dispatcher, dtype=pc.param_type.storage_encoding, fill_value=pc.param_type.fill_value, mode=self.mode, inline_data_writes=inline_data_writes, auto_flush=auto_flush_values)
+                    s = PersistedStorage(md, mm, self._persistence_layer.brick_dispatcher, dtype=pc.param_type.storage_encoding, fill_value=pc.param_type.fill_value, mode=self.mode, inline_data_writes=inline_data_writes, auto_flush=auto_flush_values)
                     self._range_value[parameter_name] = get_value_class(param_type=pc.param_type, domain_set=pc.dom, storage=s)
                     if parameter_name in self._persistence_layer.parameter_bounds:
                         bmin, bmax = self._persistence_layer.parameter_bounds[parameter_name]

--- a/coverage_model/coverage.py
+++ b/coverage_model/coverage.py
@@ -163,14 +163,10 @@ class AbstractCoverage(AbstractIdentifiable):
         # Expand the shape of the temporal_domain - following works if extents is a list or tuple
         shp.extents = (shp.extents[0]+count,)+tuple(shp.extents[1:])
 
+        self._persistence_layer.expand_domain(shp.extents)
+
         # Expand the temporal dimension of each of the parameters - the parameter determines how to apply the change
         for n in self._range_dictionary:
-            pc = self._range_dictionary.get_context(n)
-            # Update the dom of the parameter_context
-            # if pc.dom.tdom is not None:
-            #     pc.dom.tdom = self.temporal_domain.shape.extents
-            if pc.name == 'time':
-                self._persistence_layer.expand_domain(pc)
             self._range_value[n].expand_content(VariabilityEnum.TEMPORAL, origin, count)
 
         # Update the temporal_domain in the master_manager, do NOT flush!!

--- a/coverage_model/coverage.py
+++ b/coverage_model/coverage.py
@@ -169,8 +169,8 @@ class AbstractCoverage(AbstractIdentifiable):
             # Update the dom of the parameter_context
             # if pc.dom.tdom is not None:
             #     pc.dom.tdom = self.temporal_domain.shape.extents
-
-            self._persistence_layer.expand_domain(pc)
+            if pc.name == 'time':
+                self._persistence_layer.expand_domain(pc)
             self._range_value[n].expand_content(VariabilityEnum.TEMPORAL, origin, count)
 
         # Update the temporal_domain in the master_manager, do NOT flush!!

--- a/coverage_model/coverage.py
+++ b/coverage_model/coverage.py
@@ -39,7 +39,7 @@ from pyon.util.async import spawn
 from coverage_model.basic_types import AbstractIdentifiable, AxisTypeEnum, MutabilityEnum, VariabilityEnum, get_valid_DomainOfApplication, Dictable, InMemoryStorage
 from coverage_model.parameter import Parameter, ParameterDictionary, ParameterContext
 from coverage_model.parameter_values import get_value_class, AbstractParameterValue
-from coverage_model.persistence import PersistenceLayer, InMemoryPersistenceLayer
+from coverage_model.persistence import PersistenceLayer, InMemoryPersistenceLayer, ViewPersistenceLayer
 from coverage_model import utils
 from copy import deepcopy
 import numpy as np
@@ -55,9 +55,21 @@ class AbstractCoverage(AbstractIdentifiable):
     TemporalTopology
     SpatialTopology
     """
+
+    VALUE_CACHE_LIMIT = 30
+
     def __init__(self, mode=None):
         AbstractIdentifiable.__init__(self)
         self._closed = False
+        self._range_dictionary = ParameterDictionary()
+        self._range_value = RangeValues()
+        self.value_caching = False
+        self._value_cache = collections.OrderedDict()
+
+        self.temporal_domain = GridDomain(GridShape('temporal',[0]), CRS.standard_temporal(), MutabilityEnum.EXTENSIBLE)
+        self.spatial_domain = None
+
+        self._persistence_layer = InMemoryPersistenceLayer()
 
         if mode is not None and isinstance(mode, str) and mode[0] in ['r','w','a','r+']:
             self.mode = mode
@@ -110,6 +122,518 @@ class AbstractCoverage(AbstractIdentifiable):
             raise StandardError('cov_obj must be an instance or subclass of AbstractCoverage: object is {0}'.format(type(cov_obj)))
 
         cov_obj.flush()
+
+    @classmethod
+    def refresh(cls):
+        raise NotImplementedError('Not implemented in AbstractCoverage')
+
+    @property
+    def temporal_parameter_name(self):
+        return self._range_dictionary.temporal_parameter_name
+
+    @property
+    def parameter_dictionary(self):
+        return deepcopy(self._range_dictionary)
+
+    def insert_timesteps(self, count, origin=None, oob=True):
+        """
+        Insert count # of timesteps beginning at the origin
+
+        The specified # of timesteps are inserted into the temporal value array at the indicated origin.  This also
+        expands the temporal dimension of the AbstractParameterValue for each parameters
+
+        @param count    The number of timesteps to insert
+        @param origin   The starting location, from which to begin the insertion
+        @param oob      Out of band operations, True will use greenlets, False will be in-band.
+        """
+        if self.closed:
+            raise IOError('I/O operation on closed file')
+
+        if self.mode == 'r':
+            raise IOError('Coverage not open for writing: mode == \'{0}\''.format(self.mode))
+
+        # Get the current shape of the temporal_dimension
+        shp = self.temporal_domain.shape
+
+        # If not provided, set the origin to the end of the array
+        if origin is None or not isinstance(origin, int):
+            origin = shp.extents[0]
+
+        # Expand the shape of the temporal_domain - following works if extents is a list or tuple
+        shp.extents = (shp.extents[0]+count,)+tuple(shp.extents[1:])
+
+        # Expand the temporal dimension of each of the parameters - the parameter determines how to apply the change
+        for n in self._range_dictionary:
+            pc = self._range_dictionary.get_context(n)
+            # Update the dom of the parameter_context
+            if pc.dom.tdom is not None:
+                pc.dom.tdom = self.temporal_domain.shape.extents
+
+            self._persistence_layer.expand_domain(pc)
+            self._range_value[n].expand_content(VariabilityEnum.TEMPORAL, origin, count)
+
+        # Update the temporal_domain in the master_manager, do NOT flush!!
+        self._persistence_layer.update_domain(tdom=self.temporal_domain, do_flush=False)
+        # Flush the master_manager & parameter_managers in a separate greenlet
+        if oob:
+            spawn(self._persistence_layer.flush)
+        else:
+            self._persistence_layer.flush()
+
+    def append_parameter(self, parameter_context):
+        """
+        Appends a ParameterContext object to the internal set for this coverage.
+
+        A <b>deep copy</b> of the supplied ParameterContext is added to self._range_dictionary.  An AbstractParameterValue of the type
+        indicated by ParameterContext.param_type is added to self._range_value.  If the ParameterContext indicates that
+        the parameter is a coordinate parameter, it is associated with the indicated axis of the appropriate CRS.
+
+        @param parameter_context    The ParameterContext to append to the coverage <b>as a copy</b>
+        @throws StandardError   If the ParameterContext.axis indicates that it is temporal and a temporal parameter
+        already exists in the coverage
+        """
+        if self.closed:
+            raise IOError('I/O operation on closed file')
+
+        if self.mode == 'r':
+            raise IOError('Coverage not open for writing: mode == \'{0}\''.format(self.mode))
+
+        if not isinstance(parameter_context, ParameterContext):
+            raise TypeError('\'parameter_context\' must be an instance of ParameterContext')
+
+        # Create a deep copy of the ParameterContext
+        pcontext = deepcopy(parameter_context)
+
+        pname = pcontext.name
+
+        no_sdom = self.spatial_domain is None
+
+        ## Determine the correct array shape
+
+        # Get the parameter variability; assign to VariabilityEnum.NONE if None
+        pv=pcontext.variability or VariabilityEnum.NONE
+        if no_sdom and pv in (VariabilityEnum.SPATIAL, VariabilityEnum.BOTH):
+            log.warn('Provided \'parameter_context\' indicates Spatial variability, but coverage has no Spatial Domain')
+
+        if pv == VariabilityEnum.TEMPORAL: # Only varies in the Temporal Domain
+            pcontext.dom = DomainSet(self.temporal_domain.shape.extents, None)
+        elif pv == VariabilityEnum.SPATIAL: # Only varies in the Spatial Domain
+            pcontext.dom = DomainSet(None, self.spatial_domain.shape.extents)
+        elif pv == VariabilityEnum.BOTH: # Varies in both domains
+            # If the Spatial Domain is only a single point on a 0d Topology, the parameter's shape is that of the Temporal Domain only
+            if no_sdom or (len(self.spatial_domain.shape.extents) == 1 and self.spatial_domain.shape.extents[0] == 0):
+                pcontext.dom = DomainSet(self.temporal_domain.shape.extents, None)
+            else:
+                pcontext.dom = DomainSet(self.temporal_domain.shape.extents, self.spatial_domain.shape.extents)
+        elif pv == VariabilityEnum.NONE: # No variance; constant
+        # CBM TODO: Not sure we can have this constraint - precludes situations like a TextType with Variablity==None...
+        #            # This is a constant - if the ParameterContext is not a ConstantType, make it one with the default 'x' expr
+        #            if not isinstance(pcontext.param_type, ConstantType):
+        #                pcontext.param_type = ConstantType(pcontext.param_type)
+
+            # The domain is the total domain - same value everywhere!!
+            # If the Spatial Domain is only a single point on a 0d Topology, the parameter's shape is that of the Temporal Domain only
+            if no_sdom or (len(self.spatial_domain.shape.extents) == 1 and self.spatial_domain.shape.extents[0] == 0):
+                pcontext.dom = DomainSet(self.temporal_domain.shape.extents, None)
+            else:
+                pcontext.dom = DomainSet(self.temporal_domain.shape.extents, self.spatial_domain.shape.extents)
+        else:
+            # Should never get here...but...
+            raise SystemError('Must define the variability of the ParameterContext: a member of VariabilityEnum')
+
+        # Assign the pname to the CRS (if applicable) and select the appropriate domain (default is the spatial_domain)
+        dom = self.spatial_domain
+        if not pcontext.axis is None and AxisTypeEnum.is_member(pcontext.axis, AxisTypeEnum.TIME):
+            dom = self.temporal_domain
+            dom.crs.axes[pcontext.axis] = pcontext.name
+        elif not no_sdom and (pcontext.axis in self.spatial_domain.crs.axes):
+            dom.crs.axes[pcontext.axis] = pcontext.name
+
+        # If this is a ParameterFunctionType parameter, provide a callback to the coverage's _range_value
+        if hasattr(pcontext, '_pval_callback'):
+            pcontext._pval_callback = self.get_parameter_values
+            pcontext._pctxt_callback = self.get_parameter_context
+
+        self._range_dictionary.add_context(pcontext)
+        s = self._initialize_storage(pcontext)
+        self._range_value[pname] = get_value_class(param_type=pcontext.param_type, domain_set=pcontext.dom, storage=s)
+
+    def _initialize_storage(self, pcontext):
+        raise NotImplementedError('Not implemented by AbstractCoverage')
+
+    def get_parameter(self, param_name):
+        """
+        Get a Parameter object by name
+
+        The Parameter object contains the ParameterContext and AbstractParameterValue associated with the param_name
+
+        @param param_name  The local name of the parameter to return
+        @returns A Parameter object containing the context and value for the specified parameter
+        @throws KeyError    The coverage does not contain a parameter with name 'param_name'
+        """
+        if self.closed:
+            raise ValueError('I/O operation on closed file')
+
+        if param_name in self._range_dictionary:
+            p = Parameter(deepcopy(self._range_dictionary.get_context(param_name)), self._range_value[param_name].shape, self._range_value[param_name])
+            return p
+        else:
+            raise KeyError('Coverage does not contain parameter \'{0}\''.format(param_name))
+
+    def list_parameters(self, coords_only=False, data_only=False):
+        """
+        List the names of the parameters contained in the coverage
+
+        @param coords_only List only the coordinate parameters
+        @param data_only   List only the data parameters (non-coordinate) - superseded by coords_only
+        @returns A list of parameter names
+        """
+        if coords_only:
+            lst=[x for x, v in self._range_dictionary.iteritems() if v[1].is_coordinate]
+        elif data_only:
+            lst=[x for x, v in self._range_dictionary.iteritems() if not v[1].is_coordinate]
+        else:
+            lst=[x for x in self._range_dictionary]
+        lst.sort()
+        return lst
+
+    def get_parameter_values(self, param_name, tdoa=None, sdoa=None, return_value=None):
+        """
+        Retrieve the value for a parameter
+
+        Returns the value from param_name.  Temporal and spatial DomainOfApplication objects can be used to
+        constrain the response.  See DomainOfApplication for details.
+
+        @param param_name   The name of the parameter
+        @param tdoa The temporal DomainOfApplication
+        @param sdoa The spatial DomainOfApplication
+        @param return_value If supplied, filled with response value - currently via OVERWRITE
+        @throws KeyError    The coverage does not contain a parameter with name 'param_name'
+        """
+        if self.closed:
+            raise ValueError('I/O operation on closed file')
+
+        if not param_name in self._range_value:
+            raise KeyError('Parameter \'{0}\' not found in coverage'.format(param_name))
+
+        if return_value is not None:
+            log.warn('Provided \'return_value\' will be OVERWRITTEN')
+
+        slice_ = []
+
+        total_shape = self.temporal_domain.shape.extents
+        tdoa = get_valid_DomainOfApplication(tdoa, total_shape)
+        log.debug('Temporal doa: %s', tdoa.slices)
+        slice_.extend(tdoa.slices)
+
+        if self.spatial_domain is not None:
+            total_shape += self.spatial_domain.shape.extents
+            sdoa = get_valid_DomainOfApplication(sdoa, total_shape[1:])
+            log.debug('Spatial doa: %s', sdoa.slices)
+            slice_.extend(sdoa.slices)
+
+        slice_ = utils.fix_slice(slice_, total_shape)
+        log.debug('Getting slice: %s', slice_)
+
+        if self.value_caching:
+            # Make slice_ fully expressed such that there are no "None" entries - this lets us ignore domain growth
+            slk = utils.express_slice(slice_, total_shape)
+            key=(param_name, utils.hash_any(slk))
+            try:
+                return_value = self._value_cache.pop(key)
+            #                print 'Vals from cache for \'%s\'' % param_name
+            except KeyError:
+            #                print 'New vals for \'%s\'' % param_name
+                return_value = self._range_value[param_name][slice_]
+                if len(self._value_cache) >= self.VALUE_CACHE_LIMIT:
+                    k, v = self._value_cache.popitem(0)
+                    v = None
+                    del k, v
+            self._value_cache[key] = return_value
+        else:
+            return_value = self._range_value[param_name][slice_]
+
+        return return_value
+
+    def set_time_values(self, value, tdoa=None):
+        """
+        Convenience method for setting time values
+
+        @param value    The value to set
+        @param tdoa The temporal DomainOfApplication; default to full Domain
+        """
+        return self.set_parameter_values(self.temporal_parameter_name, value, tdoa, None)
+
+    def get_time_values(self, tdoa=None, return_value=None):
+        """
+        Convenience method for retrieving time values
+
+        Delegates to get_parameter_values, supplying the temporal parameter name and sdoa == None
+        @param tdoa The temporal DomainOfApplication; default to full Domain
+        @param return_value If supplied, filled with response value
+        """
+        return self.get_parameter_values(self.temporal_parameter_name, tdoa, None, return_value)
+
+    @property
+    def num_timesteps(self):
+        """
+        The current number of timesteps
+        """
+        return self.temporal_domain.shape.extents[0]
+
+    def set_parameter_values(self, param_name, value, tdoa=None, sdoa=None):
+        """
+        Assign value to the specified parameter
+
+        Assigns the value to param_name within the coverage.  Temporal and spatial DomainOfApplication objects can be
+        applied to constrain the assignment.  See DomainOfApplication for details
+
+        @param param_name   The name of the parameter
+        @param value    The value to set
+        @param tdoa The temporal DomainOfApplication
+        @param sdoa The spatial DomainOfApplication
+        @throws KeyError    The coverage does not contain a parameter with name 'param_name'
+        """
+        if self.closed:
+            raise IOError('I/O operation on closed file')
+
+        if self.mode == 'r':
+            raise IOError('Coverage not open for writing: mode == \'{0}\''.format(self.mode))
+
+        if not param_name in self._range_value:
+            raise KeyError('Parameter \'{0}\' not found in coverage_model'.format(param_name))
+
+        slice_ = []
+
+        tdoa = get_valid_DomainOfApplication(tdoa, self.temporal_domain.shape.extents)
+        log.debug('Temporal doa: %s', tdoa.slices)
+        slice_.extend(tdoa.slices)
+
+        if self.spatial_domain is not None:
+            sdoa = get_valid_DomainOfApplication(sdoa, self.spatial_domain.shape.extents)
+            log.debug('Spatial doa: %s', sdoa.slices)
+            slice_.extend(sdoa.slices)
+
+        log.debug('Setting slice: %s', slice_)
+
+        self._range_value[param_name][slice_] = value
+        # Update parameter bounds in the persistence layer
+        self._persistence_layer.update_parameter_bounds(param_name, self._range_value[param_name].bounds)
+
+
+    def clear_value_cache(self):
+        if self.value_caching:
+            self._value_cache.clear()
+
+    def get_parameter_context(self, param_name):
+        """
+        Retrieve a deepcopy of the ParameterContext object for the specified parameter
+
+        @param param_name   The name of the parameter for which to retrieve context
+        @returns A deepcopy of the specified ParameterContext object
+        @throws KeyError    The coverage does not contain a parameter with name 'param_name'
+        """
+        if not param_name in self._range_dictionary:
+            raise KeyError('Parameter \'{0}\' not found in coverage'.format(param_name))
+
+        return deepcopy(self._range_dictionary.get_context(param_name))
+
+    def _axis_arg_to_params(self, axis=None):
+        """
+        Helper function to compose a list of parameter names based on the <i>axis</i> argument
+
+        If <i>axis</i> is None, all coordinate parameters are included
+
+        @param axis A member of AxisTypeEnum; may be an iterable of such members
+        """
+        params = []
+        if axis is None:
+            params.extend(pn for pk, pn in self.temporal_domain.crs.axes.iteritems())
+            params.extend(pn for pk, pn in self.spatial_domain.crs.axes.iteritems())
+        elif hasattr(axis, '__iter__'):
+            for a in axis:
+                if a in self.temporal_domain.crs.axes:
+                    params.append(self.temporal_domain.crs.axes[a])
+                elif a in self.spatial_domain.crs.axes:
+                    params.append(self.spatial_domain.crs.axes[a])
+                else:
+                    raise ValueError('Specified axis ({0}) not found in coverage'.format(a))
+        elif axis in self.temporal_domain.crs.axes:
+            params.append(self.temporal_domain.crs.axes[axis])
+        elif axis in self.spatial_domain.crs.axes:
+            params.append(self.spatial_domain.crs.axes[axis])
+        else:
+            raise ValueError('Specified axis ({0}) not found in coverage'.format(axis))
+
+        return params
+
+    def _parameter_name_arg_to_params(self, parameter_name=None, pdict=None):
+        """
+        Helper function to compose a list of parameter names based on the <i>parameter_name</i> argument
+
+        If <i>parameter_name</i> is None, all parameters in the coverage are included
+        The <i>pdict</i> argument is used to check for validity of <i>parameter_name</i>
+
+        @param parameter_name A string parameter name; may be an iterable of such members
+        @pdict  A ParameterDictionary; self._range_dictionary if None
+        """
+        if pdict is None:
+            pdict = self._range_dictionary
+        params = []
+        if parameter_name is None:
+            params.extend(pdict.keys())
+        elif hasattr(parameter_name, '__iter__'):
+            params.extend(pn for pn in parameter_name)
+        else:
+            params.append(parameter_name)
+
+        # Verify
+        invalid_params = set(params).difference(set(pdict.keys()))
+        log.warn(invalid_params)
+
+        if None in invalid_params:
+            invalid_params = ''
+
+        if len(invalid_params) != 0:
+            raise ValueError('Coverage does not have parameters: \'{0}\''.format(invalid_params))
+
+        if None in params:
+            params = ''
+
+        return params
+
+    def get_data_bounds(self, parameter_name=None):
+        """
+        Returns the bounds (min, max) for the parameter(s) indicated by <i>parameter_name</i>
+
+        If <i>parameter_name</i> is None, all parameters in the coverage are included
+
+        If more than one parameter is indicated by <i>parameter_name</i>, a dict of {key:(min,max)} is returned;
+        otherwise, only the (min, max) tuple is returned
+
+        @param parameter_name   A string parameter name; may be an iterable of such members
+        """
+
+        if self.num_timesteps == 0:
+            raise ValueError('The coverage has no data!')
+
+        ret = {}
+        for pn in self._parameter_name_arg_to_params(parameter_name):
+            ret[pn] = self._range_value[pn].bounds
+
+        if len(ret) == 1:
+            ret = ret.values()[0]
+        return ret
+
+    def get_data_bounds_by_axis(self, axis=None):
+        """
+        Returns the bounds (min, max) for the coordinate parameter(s) indicated by <i>axis</i>
+
+        If <i>axis</i> is None, all coordinate parameters are included
+
+        If more than one parameter is indicated by <i>axis</i>, a dict of {key:(min,max)} is returned;
+        otherwise, only the (min, max) tuple is returned
+
+        @param axis   A member of AxisTypeEnum; may be an iterable of such members
+        """
+        return self.get_data_bounds(self._axis_arg_to_params(axis))
+
+    def get_data_extents(self, parameter_name=None):
+        """
+        Returns the extents (dim_0,dim_1,...,dim_n) for the parameter(s) indicated by <i>parameter_name</i>
+
+        If <i>parameter_name</i> is None, all parameters in the coverage are included
+
+        If more than one parameter is indicated by <i>parameter_name</i>, a dict of {key:(dim_0,dim_1,...,dim_n)} is returned;
+        otherwise, only the (dim_0,dim_1,...,dim_n) tuple is returned
+
+        @param parameter_name   A string parameter name; may be an iterable of such members
+        """
+        ret = {}
+        for pn in self._parameter_name_arg_to_params(parameter_name):
+            p = self._range_dictionary.get_context(pn)
+            ret[pn] = p.dom.total_extents
+
+        if len(ret) == 1:
+            ret = ret.values()[0]
+        return ret
+
+    def get_data_extents_by_axis(self, axis=None):
+        """
+        Returns the extents (dim_0,dim_1,...,dim_n) for the coordinate parameter(s) indicated by <i>axis</i>
+
+        If <i>axis</i> is None, all coordinate parameters are included
+
+        If more than one parameter is indicated by <i>axis</i>, a dict of {key:(dim_0,dim_1,...,dim_n)} is returned;
+        otherwise, only the (dim_0,dim_1,...,dim_n) tuple is returned
+
+        @param axis   A member of AxisTypeEnum; may be an iterable of such members
+        """
+        return self.get_data_extents(self._axis_arg_to_params(axis))
+
+    def get_data_size(self, parameter_name=None, slice_=None, in_bytes=False):
+        """
+        Returns the size of the <b>data values</b> for the parameter(s) indicated by <i>parameter_name</i>.
+        ParameterContext and Coverage metadata is <b>NOT</b> included in the returned size.
+
+        If <i>parameter_name</i> is None, all parameters in the coverage are included
+
+        If more than one parameter is indicated by <i>parameter_name</i>, the sum of the indicated parameters is returned
+
+        If <i>slice_</i> is not None, it is applied to each parameter (after being run through utils.fix_slice) before
+        calculation of size
+
+        Sizes are calculated as:
+            size = itemsize * total_extent_size
+
+        where:
+            itemsize == the per-item size based on the data type of the parameter
+            total_extent_size == the total number of elements after slicing is applied (if applicable)
+
+        Sizes are in MB unless <i>in_bytes</i> == True
+
+        @param parameter_name   A string parameter name; may be an iterable of such members
+        @param slice_   If not None, applied to each parameter before calculation of size
+        @param in_bytes If True, returns the size in bytes; otherwise, returns the size in MB (default)
+        """
+        size = 0
+        if parameter_name is None:
+            for pn in self._range_dictionary.keys():
+                size += self.get_data_size(pn, in_bytes=in_bytes)
+
+        for pn in self._parameter_name_arg_to_params(parameter_name):
+            p = self._range_dictionary.get_context(pn)
+            te=p.dom.total_extents
+            dt = np.dtype(p.param_type.value_encoding)
+
+            if slice_ is not None:
+                slice_ = utils.fix_slice(slice_, te)
+                a=np.empty(te, dtype=dt)[slice_]
+                size += a.nbytes
+            else:
+                size += dt.itemsize * utils.prod(te)
+
+        if not in_bytes:
+            size *= 9.53674e-7
+
+        return size
+
+    @property
+    def persistence_guid(self):
+        if isinstance(self._persistence_layer, InMemoryPersistenceLayer):
+            return None
+        else:
+            return self._persistence_layer.guid
+
+    @property
+    def persistence_dir(self):
+        if isinstance(self._persistence_layer, InMemoryPersistenceLayer):
+            return None
+        else:
+            return self._persistence_layer.master_manager.root_dir
+
+    def _initialize_storage(self, pcontext):
+        return self._persistence_layer.init_parameter(pcontext, self._bricking_scheme)
 
     def has_dirty_values(self):
         return self._persistence_layer.has_dirty_values()
@@ -178,29 +702,182 @@ class AbstractCoverage(AbstractIdentifiable):
 #
 #        return ccov
 
+    @property
+    def info(self):
+        """
+        Returns a detailed string representation of the coverage contents
+        @returns    string of coverage contents
+        """
+        lst = []
+        indent = ' '
+        lst.append('ID: {0}'.format(self._id))
+        lst.append('Name: {0}'.format(self.name))
+        lst.append('Temporal Domain:\n{0}'.format(self.temporal_domain.__str__(indent*2)))
+        lst.append('Spatial Domain:\n{0}'.format(self.spatial_domain.__str__(indent*2)))
+
+        lst.append('Parameters:')
+        for x in self._range_value:
+            lst.append('{0}{1} {2}\n{3}'.format(indent*2,x,self._range_value[x].shape,self._range_dictionary.get_context(x).__str__(indent*4)))
+
+        return '\n'.join(lst)
+
+    def __str__(self):
+        lst = []
+        indent = ' '
+        lst.append('ID: {0}'.format(self._id))
+        lst.append('Name: {0}'.format(self.name))
+        lst.append('TemporalDomain: Shape=>{0} Axes=>{1}'.format(self.temporal_domain.shape.extents, self.temporal_domain.crs.axes))
+        lst.append('SpatialDomain: Shape=>{0} Axes=>{1}'.format(self.spatial_domain.shape.extents, self.spatial_domain.crs.axes))
+        lst.append('Coordinate Parameters: {0}'.format(self.list_parameters(coords_only=True)))
+        lst.append('Data Parameters: {0}'.format(self.list_parameters(coords_only=False, data_only=True)))
+
+        return '\n'.join(lst)
+
     def __del__(self):
         self.close()
 
+
 class ViewCoverage(AbstractCoverage):
-    # TODO: Implement
+    # TODO: Implement ViewCoverage
     """
     References 1 AbstractCoverage and applies a Filter
     """
-    def __init__(self):
-        AbstractCoverage.__init__(self)
+    def __init__(self, root_dir, persistence_guid, reference_coverage_location=None, name=None, parameter_dictionary=None, mode=None):
+        AbstractCoverage.__init__(self, mode=mode)
 
-        self.reference_coverage = ''
-        self.structure_filter = StructureFilter()
-        self.parameter_filter = ParameterFilter()
+        try:
+            # Make sure root_dir and persistence_guid are both not None and are strings
+            if not isinstance(root_dir, str) or not isinstance(persistence_guid, str):
+                raise TypeError('\'root_dir\' and \'persistence_guid\' must be instances of str')
+
+            root_dir = root_dir if not root_dir.endswith(persistence_guid) else os.path.split(root_dir)[0]
+
+            pth = os.path.join(root_dir, persistence_guid)
+
+            def _doload(self):
+                # Make sure the coverage directory exists
+                if not os.path.exists(pth):
+                    raise SystemError('Cannot find specified coverage: {0}'.format(pth))
+
+                self._persistence_layer = ViewPersistenceLayer(root_dir, persistence_guid, mode=self.mode)
+
+                self.reference_coverage = AbstractCoverage.load(self._persistence_layer.rcov_loc, mode='r')
+
+                self.__setup(self._persistence_layer.param_dict)
+
+            if reference_coverage_location is None or name is None or parameter_dictionary is None:
+                # This appears to be a load
+                _doload(self)
+            else:
+                # This appears to be a new coverage
+                # Make sure name and parameter_dictionary are not None
+                if reference_coverage_location is None or name is None or parameter_dictionary is None:
+                    raise SystemError('\'reference_coverage_location\', \'name\' and \'parameter_dictionary\' cannot be None')
+
+                # If the coverage directory exists, load it instead!!
+                if os.path.exists(pth):
+                    log.warn('The specified coverage already exists - performing load of \'{0}\''.format(pth))
+                    _doload(self)
+                    return
+
+                if not isinstance(reference_coverage_location, str):
+                    raise TypeError('\'reference_coverage_location\' must be of type str')
+
+                if not os.path.exists(reference_coverage_location):
+                    raise IOError('\'reference_coverage_location\' cannot be found: \'{0}\''.format(reference_coverage_location))
+
+                # We've checked everything we can - this is a new coverage!!!
+
+                # Check the mode - must be in 'a' for a new coverage
+                if self.mode != 'a':
+                    self.mode = 'a'
+
+                if not isinstance(name, basestring):
+                    raise TypeError('\'name\' must be of type basestring')
+                self.name = name
+
+                # Open the reference coverage - ALWAYS in read-only mode
+                self.reference_coverage = AbstractCoverage.load(reference_coverage_location, mode='r')
+
+                self.__setup(parameter_dictionary)
+
+                self._persistence_layer = ViewPersistenceLayer(root_dir, persistence_guid, rcov_loc=reference_coverage_location, name=self.name, param_dict=parameter_dictionary, mode=self.mode)
+
+        except:
+            self._closed = True
+            raise
+
+    def __setup(self, parameter_dictionary):
+        for p in parameter_dictionary:
+            if p in self.reference_coverage._range_dictionary:
+                # Add the context from the reference coverage
+                self._range_dictionary.add_context(self.reference_coverage._range_dictionary.get_context(p))
+                # Add the value class from the reference coverage
+                self._range_value[p] = self.reference_coverage._range_value[p]
+            else:
+                log.warn('Parameter \'{0}\' skipped; not in \'reference_coverage\'')
+
+        self.temporal_domain = self.reference_coverage.temporal_domain
+        self.spatial_domain = self.reference_coverage.spatial_domain
+
+    def insert_timesteps(self, count, origin=None):
+        raise TypeError('Cannot insert timesteps into a ViewCoverage')
+
+    def set_time_values(self, value, tdoa=None):
+        raise TypeError('Cannot set time values against a ViewCoverage')
+
+    def set_parameter_values(self, param_name, value, tdoa=None, sdoa=None):
+        raise TypeError('Cannot set parameter values against a ViewCoverage')
+
+    def refresh(self):
+        self.close()
+
+        self.__init__(os.path.split(self.persistence_dir)[0],
+            self.persistence_guid,
+            reference_coverage_location=self.reference_coverage.persistence_dir,
+            mode=self.mode)
+
 
 class ComplexCoverage(AbstractCoverage):
     # TODO: Implement
     """
     References 1-n coverages
     """
-    def __init__(self):
+    def __init__(self, root_dir, persistence_guid, reference_coverages=None, additional_parameters=None, join_axis=0):
         AbstractCoverage.__init__(self)
-        self.coverages = []
+        if join_axis == 0:
+            # Complex parametric - combine parameters from multiple coverages
+            self._build_parametric(reference_coverages)
+        elif join_axis == 1:
+            # Complex temporal - combine coverages temporally
+            raise NotImplementedError('Not yet implemented')
+        elif join_axis == 2:
+            # Complex spatial - combine coverages across a higher-order topology
+            raise NotImplementedError('Not yet implemented')
+
+    def _build_parametric(self, rcovs, additional_params):
+        self._reference_covs = {}
+        self._params = {}
+        ntimes = None
+
+        for p in additional_params:
+            self._params[p.name] = p
+
+        for cpth in rcovs:
+            cov = AbstractCoverage.load(cpth)
+            if ntimes is None:
+                ntimes = cov.num_timesteps
+            else:
+                if ntimes != cov.num_timesteps:
+                    raise ValueError('Coverage does not have correct # of timestseps: {0}'.format(cpth))
+
+            if not cpth in self._reference_covs:
+                self._reference_covs[cpth] = cov
+
+            for p in cov.list_parameters():
+                if not p in self._params:
+                    self._params[p] = self._reference_covs[cpth]
+
 
 class SimplexCoverage(AbstractCoverage):
     """
@@ -210,8 +887,6 @@ class SimplexCoverage(AbstractCoverage):
     of the AbstractParameterValue class.
 
     """
-
-    VALUE_CACHE_LIMIT = 30
 
     def __init__(self, root_dir, persistence_guid, name=None, parameter_dictionary=None, temporal_domain=None, spatial_domain=None, mode=None, in_memory_storage=False, bricking_scheme=None, inline_data_writes=True, auto_flush_values=True, value_caching=True):
         """
@@ -252,9 +927,6 @@ class SimplexCoverage(AbstractCoverage):
                 self.spatial_domain = self._persistence_layer.sdom
                 self.temporal_domain = self._persistence_layer.tdom
 
-                self._range_dictionary = ParameterDictionary()
-                self._range_value = RangeValues()
-
                 self._bricking_scheme = self._persistence_layer.global_bricking_scheme
 
                 self._in_memory_storage = False
@@ -262,8 +934,6 @@ class SimplexCoverage(AbstractCoverage):
                 auto_flush_values = self._persistence_layer.auto_flush_values
                 inline_data_writes = self._persistence_layer.inline_data_writes
                 self.value_caching = self._persistence_layer.value_caching
-                if self.value_caching:
-                    self._value_cache = collections.OrderedDict()
 
                 from coverage_model.persistence import PersistedStorage
                 for parameter_name in self._persistence_layer.parameter_metadata.keys():
@@ -323,14 +993,10 @@ class SimplexCoverage(AbstractCoverage):
 
                 if not isinstance(parameter_dictionary, ParameterDictionary):
                     raise TypeError('\'parameter_dictionary\' must be of type ParameterDictionary')
-                self._range_dictionary = ParameterDictionary()
-                self._range_value = RangeValues()
 
                 self._bricking_scheme = bricking_scheme or {'brick_size':100000,'chunk_size':100000}
 
                 self.value_caching = value_caching
-                if self.value_caching:
-                    self._value_cache = collections.OrderedDict()
 
                 self._in_memory_storage = in_memory_storage
                 if self._in_memory_storage:
@@ -339,7 +1005,7 @@ class SimplexCoverage(AbstractCoverage):
                     self._persistence_layer = PersistenceLayer(root_dir, persistence_guid, name=name, tdom=temporal_domain, sdom=spatial_domain, mode=self.mode, bricking_scheme=self._bricking_scheme, inline_data_writes=inline_data_writes, auto_flush_values=auto_flush_values, value_caching=value_caching)
 
                 for o, pc in parameter_dictionary.itervalues():
-                    self._append_parameter(pc)
+                    self.append_parameter(pc)
         except:
             self._closed = True
             raise
@@ -348,531 +1014,10 @@ class SimplexCoverage(AbstractCoverage):
     def _fromdict(cls, cmdict, arg_masks=None):
         return super(SimplexCoverage, cls)._fromdict(cmdict, {'parameter_dictionary':'_range_dictionary'})
 
-    @property
-    def temporal_parameter_name(self):
-        return self._range_dictionary.temporal_parameter_name
-
-    @property
-    def parameter_dictionary(self):
-        return deepcopy(self._range_dictionary)
-
-    @property
-    def persistence_guid(self):
-        if isinstance(self._persistence_layer, InMemoryPersistenceLayer):
-            return None
-        else:
-            return self._persistence_layer.guid
-
-    @property
-    def persistence_dir(self):
-        if isinstance(self._persistence_layer, InMemoryPersistenceLayer):
-            return None
-        else:
-            return self._persistence_layer.master_manager.root_dir
-
-    def append_parameter(self, parameter_context):
-        """
-        Append a ParameterContext to the coverage
-
-        @deprecated use a ParameterDictionary during construction of the coverage
-        """
-        log.warn('SimplexCoverage.append_parameter() is deprecated: use a ParameterDictionary during construction of the coverage')
-        self._append_parameter(parameter_context)
-
-    def _append_parameter(self, parameter_context):
-        """
-        Appends a ParameterContext object to the internal set for this coverage.
-
-        A <b>deep copy</b> of the supplied ParameterContext is added to self._range_dictionary.  An AbstractParameterValue of the type
-        indicated by ParameterContext.param_type is added to self._range_value.  If the ParameterContext indicates that
-        the parameter is a coordinate parameter, it is associated with the indicated axis of the appropriate CRS.
-
-        @param parameter_context    The ParameterContext to append to the coverage <b>as a copy</b>
-        @throws StandardError   If the ParameterContext.axis indicates that it is temporal and a temporal parameter
-        already exists in the coverage
-        """
-        if self.closed:
-            raise IOError('I/O operation on closed file')
-
-        if self.mode == 'r':
-            raise IOError('Coverage not open for writing: mode == \'{0}\''.format(self.mode))
-
-        if not isinstance(parameter_context, ParameterContext):
-            raise TypeError('\'parameter_context\' must be an instance of ParameterContext')
-
-        # Create a deep copy of the ParameterContext
-        pcontext = deepcopy(parameter_context)
-
-        pname = pcontext.name
-
-        no_sdom = self.spatial_domain is None
-
-        ## Determine the correct array shape
-
-        # Get the parameter variability; assign to VariabilityEnum.NONE if None
-        pv=pcontext.variability or VariabilityEnum.NONE
-        if no_sdom and pv in (VariabilityEnum.SPATIAL, VariabilityEnum.BOTH):
-            log.warn('Provided \'parameter_context\' indicates Spatial variability, but coverage has no Spatial Domain')
-
-        if pv == VariabilityEnum.TEMPORAL: # Only varies in the Temporal Domain
-            pcontext.dom = DomainSet(self.temporal_domain.shape.extents, None)
-        elif pv == VariabilityEnum.SPATIAL: # Only varies in the Spatial Domain
-            pcontext.dom = DomainSet(None, self.spatial_domain.shape.extents)
-        elif pv == VariabilityEnum.BOTH: # Varies in both domains
-            # If the Spatial Domain is only a single point on a 0d Topology, the parameter's shape is that of the Temporal Domain only
-            if no_sdom or (len(self.spatial_domain.shape.extents) == 1 and self.spatial_domain.shape.extents[0] == 0):
-                pcontext.dom = DomainSet(self.temporal_domain.shape.extents, None)
-            else:
-                pcontext.dom = DomainSet(self.temporal_domain.shape.extents, self.spatial_domain.shape.extents)
-        elif pv == VariabilityEnum.NONE: # No variance; constant
-            # CBM TODO: Not sure we can have this constraint - precludes situations like a TextType with Variablity==None...
-#            # This is a constant - if the ParameterContext is not a ConstantType, make it one with the default 'x' expr
-#            if not isinstance(pcontext.param_type, ConstantType):
-#                pcontext.param_type = ConstantType(pcontext.param_type)
-
-            # The domain is the total domain - same value everywhere!!
-            # If the Spatial Domain is only a single point on a 0d Topology, the parameter's shape is that of the Temporal Domain only
-            if no_sdom or (len(self.spatial_domain.shape.extents) == 1 and self.spatial_domain.shape.extents[0] == 0):
-                pcontext.dom = DomainSet(self.temporal_domain.shape.extents, None)
-            else:
-                pcontext.dom = DomainSet(self.temporal_domain.shape.extents, self.spatial_domain.shape.extents)
-        else:
-            # Should never get here...but...
-            raise SystemError('Must define the variability of the ParameterContext: a member of VariabilityEnum')
-
-        # Assign the pname to the CRS (if applicable) and select the appropriate domain (default is the spatial_domain)
-        dom = self.spatial_domain
-        if not pcontext.axis is None and AxisTypeEnum.is_member(pcontext.axis, AxisTypeEnum.TIME):
-            dom = self.temporal_domain
-            dom.crs.axes[pcontext.axis] = pcontext.name
-        elif not no_sdom and (pcontext.axis in self.spatial_domain.crs.axes):
-            dom.crs.axes[pcontext.axis] = pcontext.name
-
-        # If this is a ParameterFunctionType parameter, provide a callback to the coverage's _range_value
-        if hasattr(pcontext, '_pval_callback'):
-            pcontext._pval_callback = self.get_parameter_values
-            pcontext._pctxt_callback = self.get_parameter_context
-
-        self._range_dictionary.add_context(pcontext)
-        s = self._persistence_layer.init_parameter(pcontext, self._bricking_scheme)
-        self._range_value[pname] = get_value_class(param_type=pcontext.param_type, domain_set=pcontext.dom, storage=s)
-
-    def get_parameter(self, param_name):
-        """
-        Get a Parameter object by name
-
-        The Parameter object contains the ParameterContext and AbstractParameterValue associated with the param_name
-
-        @param param_name  The local name of the parameter to return
-        @returns A Parameter object containing the context and value for the specified parameter
-        @throws KeyError    The coverage does not contain a parameter with name 'param_name'
-        """
-        if self.closed:
-            raise ValueError('I/O operation on closed file')
-
-        if param_name in self._range_dictionary:
-            p = Parameter(deepcopy(self._range_dictionary.get_context(param_name)), self._range_value[param_name].shape, self._range_value[param_name])
-            return p
-        else:
-            raise KeyError('Coverage does not contain parameter \'{0}\''.format(param_name))
-
-    def list_parameters(self, coords_only=False, data_only=False):
-        """
-        List the names of the parameters contained in the coverage
-
-        @param coords_only List only the coordinate parameters
-        @param data_only   List only the data parameters (non-coordinate) - superseded by coords_only
-        @returns A list of parameter names
-        """
-        if coords_only:
-            lst=[x for x, v in self._range_dictionary.iteritems() if v[1].is_coordinate]
-        elif data_only:
-            lst=[x for x, v in self._range_dictionary.iteritems() if not v[1].is_coordinate]
-        else:
-            lst=[x for x in self._range_dictionary]
-        lst.sort()
-        return lst
-
-    def insert_timesteps(self, count, origin=None, oob=True):
-        """
-        Insert count # of timesteps beginning at the origin
-
-        The specified # of timesteps are inserted into the temporal value array at the indicated origin.  This also
-        expands the temporal dimension of the AbstractParameterValue for each parameters
-
-        @param count    The number of timesteps to insert
-        @param origin   The starting location, from which to begin the insertion
-        @param oob      Out of band operations, True will use greenlets, False will be in-band.
-        """
-        if self.closed:
-            raise IOError('I/O operation on closed file')
-
-        if self.mode == 'r':
-            raise IOError('Coverage not open for writing: mode == \'{0}\''.format(self.mode))
-
-        # Get the current shape of the temporal_dimension
-        shp = self.temporal_domain.shape
-
-        # If not provided, set the origin to the end of the array
-        if origin is None or not isinstance(origin, int):
-            origin = shp.extents[0]
-
-        # Expand the shape of the temporal_domain - following works if extents is a list or tuple
-        shp.extents = (shp.extents[0]+count,)+tuple(shp.extents[1:])
-
-        # Expand the temporal dimension of each of the parameters - the parameter determines how to apply the change
-        for n in self._range_dictionary:
-            pc = self._range_dictionary.get_context(n)
-            # Update the dom of the parameter_context
-            if pc.dom.tdom is not None:
-                pc.dom.tdom = self.temporal_domain.shape.extents
-
-            self._persistence_layer.expand_domain(pc)
-            self._range_value[n].expand_content(VariabilityEnum.TEMPORAL, origin, count)
-
-        # Update the temporal_domain in the master_manager, do NOT flush!!
-        self._persistence_layer.update_domain(tdom=self.temporal_domain, do_flush=False)
-        # Flush the master_manager & parameter_managers in a separate greenlet
-        if oob:
-            spawn(self._persistence_layer.flush)
-        else:
-            self._persistence_layer.flush()
-
-    def set_time_values(self, value, tdoa=None):
-        """
-        Convenience method for setting time values
-
-        @param value    The value to set
-        @param tdoa The temporal DomainOfApplication; default to full Domain
-        """
-        return self.set_parameter_values(self.temporal_parameter_name, value, tdoa, None)
-
-    def get_time_values(self, tdoa=None, return_value=None):
-        """
-        Convenience method for retrieving time values
-
-        Delegates to get_parameter_values, supplying the temporal parameter name and sdoa == None
-        @param tdoa The temporal DomainOfApplication; default to full Domain
-        @param return_value If supplied, filled with response value
-        """
-        return self.get_parameter_values(self.temporal_parameter_name, tdoa, None, return_value)
-
-    @property
-    def num_timesteps(self):
-        """
-        The current number of timesteps
-        """
-        return self.temporal_domain.shape.extents[0]
-
-    def set_parameter_values(self, param_name, value, tdoa=None, sdoa=None):
-        """
-        Assign value to the specified parameter
-
-        Assigns the value to param_name within the coverage.  Temporal and spatial DomainOfApplication objects can be
-        applied to constrain the assignment.  See DomainOfApplication for details
-
-        @param param_name   The name of the parameter
-        @param value    The value to set
-        @param tdoa The temporal DomainOfApplication
-        @param sdoa The spatial DomainOfApplication
-        @throws KeyError    The coverage does not contain a parameter with name 'param_name'
-        """
-        if self.closed:
-            raise IOError('I/O operation on closed file')
-
-        if self.mode == 'r':
-            raise IOError('Coverage not open for writing: mode == \'{0}\''.format(self.mode))
-
-        if not param_name in self._range_value:
-            raise KeyError('Parameter \'{0}\' not found in coverage_model'.format(param_name))
-
-        slice_ = []
-
-        tdoa = get_valid_DomainOfApplication(tdoa, self.temporal_domain.shape.extents)
-        log.debug('Temporal doa: %s', tdoa.slices)
-        slice_.extend(tdoa.slices)
-
-        if self.spatial_domain is not None:
-            sdoa = get_valid_DomainOfApplication(sdoa, self.spatial_domain.shape.extents)
-            log.debug('Spatial doa: %s', sdoa.slices)
-            slice_.extend(sdoa.slices)
-
-        log.debug('Setting slice: %s', slice_)
-
-        self._range_value[param_name][slice_] = value
-        # Update parameter bounds in the persistence layer
-        self._persistence_layer.update_parameter_bounds(param_name, self._range_value[param_name].bounds)
-
-    def get_parameter_values(self, param_name, tdoa=None, sdoa=None, return_value=None):
-        """
-        Retrieve the value for a parameter
-
-        Returns the value from param_name.  Temporal and spatial DomainOfApplication objects can be used to
-        constrain the response.  See DomainOfApplication for details.
-
-        @param param_name   The name of the parameter
-        @param tdoa The temporal DomainOfApplication
-        @param sdoa The spatial DomainOfApplication
-        @param return_value If supplied, filled with response value - currently via OVERWRITE
-        @throws KeyError    The coverage does not contain a parameter with name 'param_name'
-        """
-        if self.closed:
-            raise ValueError('I/O operation on closed file')
-
-        if not param_name in self._range_value:
-            raise KeyError('Parameter \'{0}\' not found in coverage'.format(param_name))
-
-        if return_value is not None:
-            log.warn('Provided \'return_value\' will be OVERWRITTEN')
-
-        slice_ = []
-
-        total_shape = self.temporal_domain.shape.extents
-        tdoa = get_valid_DomainOfApplication(tdoa, total_shape)
-        log.debug('Temporal doa: %s', tdoa.slices)
-        slice_.extend(tdoa.slices)
-
-        if self.spatial_domain is not None:
-            total_shape += self.spatial_domain.shape.extents
-            sdoa = get_valid_DomainOfApplication(sdoa, total_shape[1:])
-            log.debug('Spatial doa: %s', sdoa.slices)
-            slice_.extend(sdoa.slices)
-
-        slice_ = utils.fix_slice(slice_, total_shape)
-        log.debug('Getting slice: %s', slice_)
-
-        if self.value_caching:
-            # Make slice_ fully expressed such that there are no "None" entries - this lets us ignore domain growth
-            slk = utils.express_slice(slice_, total_shape)
-            key=(param_name, utils.hash_any(slk))
-            try:
-                return_value = self._value_cache.pop(key)
-#                print 'Vals from cache for \'%s\'' % param_name
-            except KeyError:
-#                print 'New vals for \'%s\'' % param_name
-                return_value = self._range_value[param_name][slice_]
-                if len(self._value_cache) >= self.VALUE_CACHE_LIMIT:
-                    k, v = self._value_cache.popitem(0)
-                    v=None
-                    del k, v
-            self._value_cache[key] = return_value
-        else:
-            return_value = self._range_value[param_name][slice_]
-
-        return return_value
-
-    def clear_value_cache(self):
-        if self.value_caching:
-            self._value_cache.clear()
-
-    def get_parameter_context(self, param_name):
-        """
-        Retrieve a deepcopy of the ParameterContext object for the specified parameter
-
-        @param param_name   The name of the parameter for which to retrieve context
-        @returns A deepcopy of the specified ParameterContext object
-        @throws KeyError    The coverage does not contain a parameter with name 'param_name'
-        """
-        if not param_name in self._range_dictionary:
-            raise KeyError('Parameter \'{0}\' not found in coverage'.format(param_name))
-
-        return deepcopy(self._range_dictionary.get_context(param_name))
-
-    def __axis_arg_to_params(self, axis=None):
-        """
-        Helper function to compose a list of parameter names based on the <i>axis</i> argument
-
-        If <i>axis</i> is None, all coordinate parameters are included
-
-        @param axis A member of AxisTypeEnum; may be an iterable of such members
-        """
-        params = []
-        if axis is None:
-            params.extend(pn for pk, pn in self.temporal_domain.crs.axes.iteritems())
-            params.extend(pn for pk, pn in self.spatial_domain.crs.axes.iteritems())
-        elif hasattr(axis, '__iter__'):
-            for a in axis:
-                if a in self.temporal_domain.crs.axes:
-                    params.append(self.temporal_domain.crs.axes[a])
-                elif a in self.spatial_domain.crs.axes:
-                    params.append(self.spatial_domain.crs.axes[a])
-                else:
-                    raise ValueError('Specified axis ({0}) not found in coverage'.format(a))
-        elif axis in self.temporal_domain.crs.axes:
-            params.append(self.temporal_domain.crs.axes[axis])
-        elif axis in self.spatial_domain.crs.axes:
-            params.append(self.spatial_domain.crs.axes[axis])
-        else:
-            raise ValueError('Specified axis ({0}) not found in coverage'.format(axis))
-
-        return params
-
-    def __parameter_name_arg_to_params(self, parameter_name=None):
-        """
-        Helper function to compose a list of parameter names based on the <i>parameter_name</i> argument
-
-        If <i>parameter_name</i> is None, all parameters in the coverage are included
-
-        @param parameter_name A string parameter name; may be an iterable of such members
-        """
-        params = []
-        if parameter_name is None:
-            params.extend(self._range_dictionary.keys())
-        elif hasattr(parameter_name, '__iter__'):
-            params.extend(pn for pn in parameter_name if pn in self._range_dictionary.keys())
-        else:
-            params.append(parameter_name)
-
-        return params
-
-    def get_data_bounds(self, parameter_name=None):
-        """
-        Returns the bounds (min, max) for the parameter(s) indicated by <i>parameter_name</i>
-
-        If <i>parameter_name</i> is None, all parameters in the coverage are included
-
-        If more than one parameter is indicated by <i>parameter_name</i>, a dict of {key:(min,max)} is returned;
-        otherwise, only the (min, max) tuple is returned
-
-        @param parameter_name   A string parameter name; may be an iterable of such members
-        """
-
-        if self.num_timesteps == 0:
-            raise ValueError('The coverage has no data!')
-
-        ret = {}
-        for pn in self.__parameter_name_arg_to_params(parameter_name):
-            ret[pn] = self._range_value[pn].bounds
-
-        if len(ret) == 1:
-            ret = ret.values()[0]
-
-        return ret
-
-    def get_data_bounds_by_axis(self, axis=None):
-        """
-        Returns the bounds (min, max) for the coordinate parameter(s) indicated by <i>axis</i>
-
-        If <i>axis</i> is None, all coordinate parameters are included
-
-        If more than one parameter is indicated by <i>axis</i>, a dict of {key:(min,max)} is returned;
-        otherwise, only the (min, max) tuple is returned
-
-        @param axis   A member of AxisTypeEnum; may be an iterable of such members
-        """
-        return self.get_data_bounds(self.__axis_arg_to_params(axis))
-
-    def get_data_extents(self, parameter_name=None):
-        """
-        Returns the extents (dim_0,dim_1,...,dim_n) for the parameter(s) indicated by <i>parameter_name</i>
-
-        If <i>parameter_name</i> is None, all parameters in the coverage are included
-
-        If more than one parameter is indicated by <i>parameter_name</i>, a dict of {key:(dim_0,dim_1,...,dim_n)} is returned;
-        otherwise, only the (dim_0,dim_1,...,dim_n) tuple is returned
-
-        @param parameter_name   A string parameter name; may be an iterable of such members
-        """
-        ret = {}
-        for pn in self.__parameter_name_arg_to_params(parameter_name):
-            p = self._range_dictionary.get_context(pn)
-            ret[pn] = p.dom.total_extents
-
-        if len(ret) == 1:
-            ret = ret.values()[0]
-
-        return ret
-
-    def get_data_extents_by_axis(self, axis=None):
-        """
-        Returns the extents (dim_0,dim_1,...,dim_n) for the coordinate parameter(s) indicated by <i>axis</i>
-
-        If <i>axis</i> is None, all coordinate parameters are included
-
-        If more than one parameter is indicated by <i>axis</i>, a dict of {key:(dim_0,dim_1,...,dim_n)} is returned;
-        otherwise, only the (dim_0,dim_1,...,dim_n) tuple is returned
-
-        @param axis   A member of AxisTypeEnum; may be an iterable of such members
-        """
-        return self.get_data_extents(self.__axis_arg_to_params(axis))
-
-    def get_data_size(self, parameter_name=None, slice_=None, in_bytes=False):
-        """
-        Returns the size of the <b>data values</b> for the parameter(s) indicated by <i>parameter_name</i>.
-        ParameterContext and Coverage metadata is <b>NOT</b> included in the returned size.
-
-        If <i>parameter_name</i> is None, all parameters in the coverage are included
-
-        If more than one parameter is indicated by <i>parameter_name</i>, the sum of the indicated parameters is returned
-
-        If <i>slice_</i> is not None, it is applied to each parameter (after being run through utils.fix_slice) before
-        calculation of size
-
-        Sizes are calculated as:
-            size = itemsize * total_extent_size
-
-        where:
-            itemsize == the per-item size based on the data type of the parameter
-            total_extent_size == the total number of elements after slicing is applied (if applicable)
-
-        Sizes are in MB unless <i>in_bytes</i> == True
-
-        @param parameter_name   A string parameter name; may be an iterable of such members
-        @param slice_   If not None, applied to each parameter before calculation of size
-        @param in_bytes If True, returns the size in bytes; otherwise, returns the size in MB (default)
-        """
-        size = 0
-        if parameter_name is None:
-            for pn in self._range_dictionary.keys():
-                size += self.get_data_size(pn, in_bytes=in_bytes)
-
-        for pn in self.__parameter_name_arg_to_params(parameter_name):
-            p = self._range_dictionary.get_context(pn)
-            te=p.dom.total_extents
-            dt = np.dtype(p.param_type.value_encoding)
-
-            if slice_ is not None:
-                slice_ = utils.fix_slice(slice_, te)
-                a=np.empty(te, dtype=dt)[slice_]
-                size += a.nbytes
-            else:
-                size += dt.itemsize * utils.prod(te)
-
-        if not in_bytes:
-            size *= 9.53674e-7
-
-        return size
-
-    @property
-    def info(self):
-        """
-        Returns a detailed string representation of the coverage contents
-        @returns    string of coverage contents
-        """
-        lst = []
-        indent = ' '
-        lst.append('ID: {0}'.format(self._id))
-        lst.append('Name: {0}'.format(self.name))
-        lst.append('Temporal Domain:\n{0}'.format(self.temporal_domain.__str__(indent*2)))
-        lst.append('Spatial Domain:\n{0}'.format(self.spatial_domain.__str__(indent*2)))
-
-        lst.append('Parameters:')
-        for x in self._range_value:
-            lst.append('{0}{1} {2}\n{3}'.format(indent*2,x,self._range_value[x].shape,self._range_dictionary.get_context(x).__str__(indent*4)))
-
-        return '\n'.join(lst)
-
-    def __str__(self):
-        lst = []
-        indent = ' '
-        lst.append('ID: {0}'.format(self._id))
-        lst.append('Name: {0}'.format(self.name))
-        lst.append('TemporalDomain: Shape=>{0} Axes=>{1}'.format(self.temporal_domain.shape.extents, self.temporal_domain.crs.axes))
-        lst.append('SpatialDomain: Shape=>{0} Axes=>{1}'.format(self.spatial_domain.shape.extents, self.spatial_domain.crs.axes))
-        lst.append('Coordinate Parameters: {0}'.format(self.list_parameters(coords_only=True)))
-        lst.append('Data Parameters: {0}'.format(self.list_parameters(coords_only=False, data_only=True)))
-
-        return '\n'.join(lst)
+    def refresh(self):
+        if not self._in_memory_storage:
+            self.close()
+            self.__init__(os.path.split(self.persistence_dir)[0], self.persistence_guid, mode=self.mode)
 
 
 #=========================

--- a/coverage_model/coverage.py
+++ b/coverage_model/coverage.py
@@ -71,7 +71,7 @@ class AbstractCoverage(AbstractIdentifiable):
 
         self._persistence_layer = InMemoryPersistenceLayer()
 
-        if mode is not None and isinstance(mode, str) and mode[0] in ['r','w','a','r+']:
+        if mode is not None and isinstance(mode, basestring) and mode[0] in ['r','w','a','r+']:
             self.mode = mode
         else:
             self.mode = 'r'
@@ -747,8 +747,8 @@ class ViewCoverage(AbstractCoverage):
 
         try:
             # Make sure root_dir and persistence_guid are both not None and are strings
-            if not isinstance(root_dir, str) or not isinstance(persistence_guid, str):
-                raise TypeError('\'root_dir\' and \'persistence_guid\' must be instances of str')
+            if not isinstance(root_dir, basestring) or not isinstance(persistence_guid, basestring):
+                raise TypeError('\'root_dir\' and \'persistence_guid\' must be instances of basestring')
 
             root_dir = root_dir if not root_dir.endswith(persistence_guid) else os.path.split(root_dir)[0]
 
@@ -780,8 +780,8 @@ class ViewCoverage(AbstractCoverage):
                     _doload(self)
                     return
 
-                if not isinstance(reference_coverage_location, str):
-                    raise TypeError('\'reference_coverage_location\' must be of type str')
+                if not isinstance(reference_coverage_location, basestring):
+                    raise TypeError('\'reference_coverage_location\' must be of type basestring')
 
                 if not os.path.exists(reference_coverage_location):
                     raise IOError('\'reference_coverage_location\' cannot be found: \'{0}\''.format(reference_coverage_location))
@@ -929,8 +929,8 @@ class SimplexCoverage(AbstractCoverage):
         AbstractCoverage.__init__(self, mode=mode)
         try:
             # Make sure root_dir and persistence_guid are both not None and are strings
-            if not isinstance(root_dir, str) or not isinstance(persistence_guid, str):
-                raise TypeError('\'root_dir\' and \'persistence_guid\' must be instances of str')
+            if not isinstance(root_dir, basestring) or not isinstance(persistence_guid, basestring):
+                raise TypeError('\'root_dir\' and \'persistence_guid\' must be instances of basestring')
 
             root_dir = root_dir if not root_dir.endswith(persistence_guid) else os.path.split(root_dir)[0]
 

--- a/coverage_model/numexpr_utils.py
+++ b/coverage_model/numexpr_utils.py
@@ -80,9 +80,9 @@ def nest_wheres(*args):
 
     @param *args    One or more str or unicode expressions that pass the is_well_formed_where function
     """
-    where_list = [w for w in args if isinstance(w, (str, unicode)) and is_well_formed_where(w)]
+    where_list = [w for w in args if isinstance(w, basestring) and is_well_formed_where(w)]
     if not where_list:
-        raise IndexError('There are no appropriate arguments; each argument must be a str/unicode matching \'where(.*,.*,.*)\'')
+        raise IndexError('There are no appropriate arguments; each argument must be a basestring matching \'where(.*,.*,.*)\'')
 
     ret = where_list[0]
     for w in where_list[1:]:

--- a/coverage_model/parameter.py
+++ b/coverage_model/parameter.py
@@ -112,8 +112,8 @@ class ParameterContext(AbstractIdentifiable):
         my_kwargs = {x:kwc.pop(x) for x in self.ATTRS if x in kwc}
         new_name = kwc.pop('new_name') if 'new_name' in kwc else None
         param_context = None
-        if not isinstance(name, (str, ParameterContext)):
-            raise SystemError('\'name\' must be an instance of either str or ParameterContext')
+        if not isinstance(name, (basestring, ParameterContext)):
+            raise SystemError('\'name\' must be an instance of either basestring or ParameterContext')
 
         if isinstance(name, ParameterContext):
             param_context = name

--- a/coverage_model/parameter_types.py
+++ b/coverage_model/parameter_types.py
@@ -667,7 +667,7 @@ class ConstantType(AbstractComplexParameterType):
             elif isinstance(value, np.ndarray):
                 if value.dtype.kind != 'S':
                     raise ValueError('\'value\' is a numpy array, with an invalid dtype; must be kind=\'S\', is kind={0}'.format(value.dtype.kind))
-            elif not isinstance(value, str):
+            elif not isinstance(value, basestring):
                 raise ValueError('\'value\' must be a string with a max length of {0}; longer strings will be truncated'.format(dt.str[dt.str.index('S')+1:]))
         else:
             # TODO: Check numeric??
@@ -753,5 +753,4 @@ class ArrayType(AbstractComplexParameterType):
         """
         kwc=kwargs.copy()
         AbstractComplexParameterType.__init__(self, value_class='ArrayValue', **kwc)
-
         self._gen_template_attrs()

--- a/coverage_model/persistence.py
+++ b/coverage_model/persistence.py
@@ -218,7 +218,7 @@ class PersistenceLayer(object):
 
         self.global_bricking_scheme = bricking_scheme
 
-        pm = ParameterManager(os.path.join(self.root_dir, self.guid, parameter_name), parameter_name)
+        pm = ParameterManager(os.path.join(self.root_dir, self.guid, parameter_name), parameter_name, read_only=False)
         self.parameter_metadata[parameter_name] = pm
 
         pm.parameter_context = parameter_context
@@ -259,6 +259,10 @@ class PersistenceLayer(object):
         # CBM TODO: Consider making this optional and bulk-flushing from the coverage after all parameters have been initialized
         # No need to check if they're dirty, we know they are!
         pm.flush()
+
+        # Put the pm into read_only mode
+        pm.read_only = True
+
         self.master_manager.flush()
 
         return v

--- a/coverage_model/persistence.py
+++ b/coverage_model/persistence.py
@@ -28,7 +28,7 @@ class SimplePersistenceLayer(object):
     def __init__(self, root, guid, name=None, param_dict=None, mode=None, **kwargs):
         root = '.' if root is ('' or None) else root
 
-        self.master_manager = MasterManager(root_dir=root, guid=guid, name=name, param_dict=param_dict, **kwargs)
+        self.master_manager = MasterManager(root_dir=root, guid=guid, name=name, param_dict=param_dict, parameter_bounds=None, **kwargs)
 
         self.mode = mode
 

--- a/coverage_model/persistence_helpers.py
+++ b/coverage_model/persistence_helpers.py
@@ -146,6 +146,9 @@ class MasterManager(BaseManager):
 
             self.param_groups = set()
             f.visit(self.param_groups.add)
+            log.warn('self.param_groups: %s', self.param_groups)
+            # TODO: Use valid parameter list to compare against inspected param_groups and discard all that are invalid
+            self.param_groups.discard('rtree')
 
             # Don't forget brick_tree!
             p = rtree.index.Property()

--- a/coverage_model/persistence_helpers.py
+++ b/coverage_model/persistence_helpers.py
@@ -128,11 +128,11 @@ class MasterManager(BaseManager):
             self.param_groups = set()
 
     def update_rtree(self, count, extents, obj):
-        log.warn('MM count: {0}'.format(count))
+        log.debug('MM count: {0}'.format(count))
         if not hasattr(self, 'brick_tree'):
             raise AttributeError('Cannot update rtree; object does not have a \'brick_tree\' attribute!!')
 
-        log.warn('self.file_path: {0}'.format(self.file_path))
+        log.debug('self.file_path: {0}'.format(self.file_path))
         with h5py.File(self.file_path, 'a') as f:
             rtree_ds = f.require_dataset('rtree', shape=(count,), dtype=h5py.special_dtype(vlen=str), maxshape=(None,))
             rtree_ds.resize((count+1,))

--- a/coverage_model/persistence_helpers.py
+++ b/coverage_model/persistence_helpers.py
@@ -175,15 +175,20 @@ class MasterManager(BaseManager):
 
 class ParameterManager(BaseManager):
 
-    def __init__(self, root_dir, parameter_name, **kwargs):
+    def __init__(self, root_dir, parameter_name, read_only=True, **kwargs):
         BaseManager.__init__(self, root_dir=root_dir, file_name='{0}.hdf5'.format(parameter_name), **kwargs)
         self.parameter_name = parameter_name
+        self.read_only = read_only
 
         # Add attributes that should NEVER be flushed
         self._ignore.update(['brick_tree', 'file_path', 'root_dir'])
 
     def thin_origins(self, origins):
         pass
+
+    def flush(self):
+        if not self.read_only:
+            super(ParameterManager, self).flush()
 
     # def update_rtree(self, count, extents, obj):
     #     log.warn('PM [{1}] count: {0}'.format(count, self.parameter_name))

--- a/coverage_model/persistence_helpers.py
+++ b/coverage_model/persistence_helpers.py
@@ -134,7 +134,7 @@ class MasterManager(BaseManager):
 
         log.warn('self.file_path: {0}'.format(self.file_path))
         with h5py.File(self.file_path, 'a') as f:
-            rtree_ds = f.require_dataset('rtree', shape=(1,), dtype=h5py.special_dtype(vlen=str), maxshape=(None,))
+            rtree_ds = f.require_dataset('rtree', shape=(count,), dtype=h5py.special_dtype(vlen=str), maxshape=(None,))
             rtree_ds.resize((count+1,))
             rtree_ds[count] = pack((extents, obj))
 
@@ -185,35 +185,35 @@ class ParameterManager(BaseManager):
     def thin_origins(self, origins):
         pass
 
-    def update_rtree(self, count, extents, obj):
-        log.warn('PM [{1}] count: {0}'.format(count, self.parameter_name))
-        if not hasattr(self, 'brick_tree'):
-            raise AttributeError('Cannot update rtree; object does not have a \'brick_tree\' attribute!!')
-
-        with h5py.File(self.file_path, 'a') as f:
-            rtree_ds = f.require_dataset('rtree', shape=(count,), dtype=h5py.special_dtype(vlen=str), maxshape=(None,))
-            rtree_ds.resize((count+1,))
-            rtree_ds[count] = pack((extents, obj))
-
-            self.brick_tree.insert(count, extents, obj=obj)
+    # def update_rtree(self, count, extents, obj):
+    #     log.warn('PM [{1}] count: {0}'.format(count, self.parameter_name))
+    #     if not hasattr(self, 'brick_tree'):
+    #         raise AttributeError('Cannot update rtree; object does not have a \'brick_tree\' attribute!!')
+    #
+    #     with h5py.File(self.file_path, 'a') as f:
+    #         rtree_ds = f.require_dataset('rtree', shape=(count,), dtype=h5py.special_dtype(vlen=str), maxshape=(None,))
+    #         rtree_ds.resize((count+1,))
+    #         rtree_ds[count] = pack((extents, obj))
+    #
+    #         self.brick_tree.insert(count, extents, obj=obj)
 
     def _load(self):
         with h5py.File(self.file_path, 'r') as f:
             self._base_load(f)
 
-            # Don't forget brick_tree!
-            p = rtree.index.Property()
-            p.dimension = self.tree_rank
-
-            if 'rtree' in f.keys():
-                # Populate brick tree from the 'rtree' dataset
-                ds = f['/rtree']
-
-                def tree_loader(darr):
-                    for i, x in enumerate(darr):
-                        ext, obj = unpack(x)
-                        yield (i, ext, obj)
-
-                setattr(self, 'brick_tree', rtree.index.Index(tree_loader(ds[:]), properties=p))
-            else:
-                setattr(self, 'brick_tree', rtree.index.Index(properties=p))
+            # # Don't forget brick_tree!
+            # p = rtree.index.Property()
+            # p.dimension = self.tree_rank
+            #
+            # if 'rtree' in f.keys():
+            #     # Populate brick tree from the 'rtree' dataset
+            #     ds = f['/rtree']
+            #
+            #     def tree_loader(darr):
+            #         for i, x in enumerate(darr):
+            #             ext, obj = unpack(x)
+            #             yield (i, ext, obj)
+            #
+            #     setattr(self, 'brick_tree', rtree.index.Index(tree_loader(ds[:]), properties=p))
+            # else:
+            #     setattr(self, 'brick_tree', rtree.index.Index(properties=p))

--- a/coverage_model/persistence_helpers.py
+++ b/coverage_model/persistence_helpers.py
@@ -87,6 +87,7 @@ class BaseManager(object):
 
             if isinstance(value, tuple):
                 value = list(value)
+
             setattr(self, key, value)
 
     def is_dirty(self, force_deep=False):
@@ -146,7 +147,6 @@ class MasterManager(BaseManager):
 
             self.param_groups = set()
             f.visit(self.param_groups.add)
-            log.warn('self.param_groups: %s', self.param_groups)
             # TODO: Use valid parameter list to compare against inspected param_groups and discard all that are invalid
             self.param_groups.discard('rtree')
 
@@ -193,35 +193,7 @@ class ParameterManager(BaseManager):
         if not self.read_only:
             super(ParameterManager, self).flush()
 
-    # def update_rtree(self, count, extents, obj):
-    #     log.warn('PM [{1}] count: {0}'.format(count, self.parameter_name))
-    #     if not hasattr(self, 'brick_tree'):
-    #         raise AttributeError('Cannot update rtree; object does not have a \'brick_tree\' attribute!!')
-    #
-    #     with h5py.File(self.file_path, 'a') as f:
-    #         rtree_ds = f.require_dataset('rtree', shape=(count,), dtype=h5py.special_dtype(vlen=str), maxshape=(None,))
-    #         rtree_ds.resize((count+1,))
-    #         rtree_ds[count] = pack((extents, obj))
-    #
-    #         self.brick_tree.insert(count, extents, obj=obj)
-
     def _load(self):
         with h5py.File(self.file_path, 'r') as f:
             self._base_load(f)
 
-            # # Don't forget brick_tree!
-            # p = rtree.index.Property()
-            # p.dimension = self.tree_rank
-            #
-            # if 'rtree' in f.keys():
-            #     # Populate brick tree from the 'rtree' dataset
-            #     ds = f['/rtree']
-            #
-            #     def tree_loader(darr):
-            #         for i, x in enumerate(darr):
-            #             ext, obj = unpack(x)
-            #             yield (i, ext, obj)
-            #
-            #     setattr(self, 'brick_tree', rtree.index.Index(tree_loader(ds[:]), properties=p))
-            # else:
-            #     setattr(self, 'brick_tree', rtree.index.Index(properties=p))

--- a/coverage_model/test/examples.py
+++ b/coverage_model/test/examples.py
@@ -509,7 +509,7 @@ def ptypescov(save_coverage=False, in_memory=False, inline_data_writes=True, mak
     cnst_rng_int_ctxt.long_name = 'example of a parameter of type ConstantRangeType, base_type int16'
     pdict.add_context(cnst_rng_int_ctxt)
 
-    func = NumexprFunction('func', expression='q*10', arg_list=['q'], param_map={'q':'quantity'})
+    func = NumexprFunction('numexpr_func', expression='q*10', arg_list=['q'], param_map={'q':'quantity'})
     pfunc_ctxt = ParameterContext('parameter_function', param_type=ParameterFunctionType(function=func), variability=VariabilityEnum.TEMPORAL)
     pfunc_ctxt.long_name = 'example of a parameter of type ParameterFunctionType'
     pdict.add_context(pfunc_ctxt)

--- a/coverage_model/test/examples.py
+++ b/coverage_model/test/examples.py
@@ -665,6 +665,88 @@ def sbe37im_samplecov(num_timesteps=100000, value_caching=True):
     return scov
 
 
+def sbe37im_complexcov(num_timesteps=10, value_caching=True):
+    # Construct temporal and spatial Coordinate Reference System objects
+    tcrs = CRS([AxisTypeEnum.TIME])
+    scrs = CRS([AxisTypeEnum.LON, AxisTypeEnum.LAT])
+
+    # Construct temporal and spatial Domain objects
+    tdom = GridDomain(GridShape('temporal', [0]), tcrs, MutabilityEnum.EXTENSIBLE) # 1d (timeline)
+    sdom = GridDomain(GridShape('spatial', [0]), scrs, MutabilityEnum.IMMUTABLE)
+
+    # Create a set of ParameterContext objects to define the parameters in the coverage, add each to the ParameterDictionary
+    from coverage_model.test.test_parameter_functions import _create_all_params
+    contexts = _create_all_params()
+
+    tctxt = contexts.pop('TIME')
+
+    # Make the llcov
+
+    # Instantiate a ParameterDictionary
+    pdict = ParameterDictionary()
+
+    pdict.add_context(tctxt, is_temporal=True)  # Add time
+    # Add lat, lon, time parameters
+    pdict.add_context(contexts.pop('LAT'))
+    pdict.add_context(contexts.pop('LON'))
+
+    # Instantiate the SimplexCoverage providing the ParameterDictionary, spatial Domain and temporal Domain
+    llcov = SimplexCoverage('test_data', create_guid(), 'lat lon coverage for an SBE 37IM', parameter_dictionary=pdict, temporal_domain=tdom, spatial_domain=sdom, value_caching=value_caching)
+
+    # Insert some timesteps (automatically expands other arrays)
+    nt = num_timesteps
+    llcov.insert_timesteps(nt)
+
+    # Add data for the llcov
+    llcov.set_parameter_values('TIME', value=np.arange(nt))
+    llcov.set_parameter_values('LAT', value=45)
+    llcov.set_parameter_values('LON', value=-71)
+
+    llcov.close()
+
+    # Make the science data cov
+    pdict = ParameterDictionary()
+    pdict.add_context(tctxt, is_temporal=True)
+
+    # Add L0 params
+    pdict.add_context(contexts.pop('TEMPWAT_L0'))
+    pdict.add_context(contexts.pop('CONDWAT_L0'))
+    pdict.add_context(contexts.pop('PRESWAT_L0'))
+
+    scov = SimplexCoverage('test_data', create_guid(), 'lat lon coverage for an SBE 37IM', parameter_dictionary=pdict, temporal_domain=tdom, spatial_domain=sdom, value_caching=value_caching)
+
+    scov.insert_timesteps(nt)
+
+    # Add data for the L0 cov
+    scov.set_parameter_values('TIME', value=np.arange(nt))
+
+    # SBE 37IM - temperature in 't_dec' example range between 280000 and 350000
+    scov.set_parameter_values('TEMPWAT_L0', value=np.random.random_sample(nt)*(350000-280000)+280000)
+    # SBE 37IM - conductivity, ranging between 100000 & 750000 (not 0 because never 0 in seawater)
+    scov.set_parameter_values('CONDWAT_L0', value=np.random.random_sample(nt)*(750000-100000)+100000)
+    # SBE 37IM - pressure, ranging between 2789 and 10000 (couldn't find a range in the DPS, this seems reasonable!)
+    scov.set_parameter_values('PRESWAT_L0', value=np.random.random_sample(nt)*(10000-2789)+2789)
+
+    scov.close()
+
+    # Make the L1/2 coverage (a complex)
+    pdict = ParameterDictionary()
+
+    pdict.add_context(tctxt, is_temporal=True)
+
+    # Add L1/L2 params
+    pdict.add_context(contexts.pop('TEMPWAT_L1'))
+    pdict.add_context(contexts.pop('CONDWAT_L1'))
+    pdict.add_context(contexts.pop('PRESWAT_L1'))
+    pdict.add_context(contexts.pop('DENSITY'))
+    pdict.add_context(contexts.pop('PRACSAL'))
+
+    ccov = ComplexCoverage('test_data', create_guid(), 'l1 l2 coverage for SBE 37IM', parameter_dictionary=pdict, reference_coverage_locs=[llcov.persistence_dir, scov.persistence_dir], complex_type=ComplexCoverageType.PARAMETRIC)
+    # ccov.insert_timesteps(nt)
+    # ccov.set_parameter_values('TIME', value=np.arange(nt))
+
+    return ccov
+
 
 def nospatialcov(save_coverage=False, in_memory=False, inline_data_writes=True):
     # Construct temporal and spatial Coordinate Reference System objects

--- a/coverage_model/test/examples.py
+++ b/coverage_model/test/examples.py
@@ -262,42 +262,23 @@ def samplecomplexcov():
     tdom = GridDomain(GridShape('temporal', [0]), tcrs, MutabilityEnum.EXTENSIBLE) # 1d (timeline)
     sdom = GridDomain(GridShape('spatial', [0]), scrs, MutabilityEnum.IMMUTABLE) # 0d spatial topology (station/trajectory)
 
-    def make_cov(pnames):
-        # Instantiate a ParameterDictionary
-        pdict = ParameterDictionary()
-
-        # Create a set of ParameterContext objects to define the parameters in the coverage, add each to the ParameterDictionary
-        t_ctxt = ParameterContext('time', param_type=QuantityType(value_encoding=np.dtype('int64')))
-        t_ctxt.uom = 'seconds since 01-01-1970'
-        pdict.add_context(t_ctxt, is_temporal=True)
-
-        for p in pnames:
-            pdict.add_context(ParameterContext(p, param_type=QuantityType(value_encoding=np.dtype('float32'))))
-
-        scov = SimplexCoverage('test_data', create_guid(), 'sample coverage_model', parameter_dictionary=pdict, temporal_domain=tdom, spatial_domain=sdom)
-
-        scov.insert_timesteps(10)
-        scov.set_parameter_values('time', range(10))
-        for p in pnames:
-            scov.set_parameter_values(p, range(10))
-
-        scov.close()
-
-        return scov.persistence_dir
-
-    cova_pth = make_cov(['first_param'])
-    covb_pth = make_cov(['second_param'])
+    from coverage_model.test.test_complex_coverage import _make_cov
+    rcov_locs = [_make_cov('test_data', ['first_param']),
+                 _make_cov('test_data', ['second_param']),
+                 _make_cov('test_data', ['third_param', 'fourth_param']),
+                 ]
 
     # Instantiate a ParameterDictionary
     pdict = ParameterDictionary()
 
     # Create a set of ParameterContext objects to define the parameters in the coverage, add each to the ParameterDictionary
-    func = NumexprFunction('a*b', 'a*b', ['a','b'], {'a': 'first_param', 'b': 'second_param'})
+    func = NumexprFunction('a*b', 'a*b', ['a', 'b'], {'a': 'first_param', 'b': 'second_param'})
     val_ctxt = ParameterContext('a*b', param_type=ParameterFunctionType(function=func, value_encoding=np.dtype('float32')))
     pdict.add_context(val_ctxt)
 
     # Instantiate the SimplexCoverage providing the ParameterDictionary, spatial Domain and temporal Domain
-    ccov = ComplexCoverage('test_data', 'test_complex', 'sample complex coverage', reference_coverages=[cova_pth, covb_pth], parameter_dictionary=pdict)
+    ccov = ComplexCoverage('test_data', 'test_complex', 'sample complex coverage', parameter_dictionary=pdict,
+                           mode='a', reference_coverage_locs=rcov_locs)
 
     return ccov
 

--- a/coverage_model/test/examples.py
+++ b/coverage_model/test/examples.py
@@ -7,7 +7,7 @@
 @brief Exemplar functions for creation, manipulation, and basic visualization of coverages
 """
 import random
-from coverage_model import PythonFunction, NumexprFunction
+from coverage_model import PythonFunction, NumexprFunction, ViewCoverage
 
 from ooi.logging import log
 from netCDF4 import Dataset
@@ -227,6 +227,31 @@ def samplecov(save_coverage=False, in_memory=False, inline_data_writes=True):
         SimplexCoverage.pickle_save(scov, 'test_data/sample.cov')
 
     return scov
+
+def sampleviewcov():
+    cov = samplecov()
+    ref_cov = cov.persistence_dir
+    cov.close()
+
+    # Instantiate a ParameterDictionary
+    pdict = ParameterDictionary()
+
+    # Create a set of ParameterContext objects to define the parameters in the coverage, add each to the ParameterDictionary
+    t_ctxt = ParameterContext('time', param_type=QuantityType(value_encoding=np.dtype('int64')))
+    t_ctxt.uom = 'seconds since 01-01-1970'
+    pdict.add_context(t_ctxt, is_temporal=True)
+
+    temp_ctxt = ParameterContext('temp', param_type=QuantityType(value_encoding=np.dtype('float32')))
+    temp_ctxt.uom = 'degree_Celsius'
+    pdict.add_context(temp_ctxt)
+
+    cov = ViewCoverage('test_data',
+                       'test_view',
+                       reference_coverage_location=ref_cov,
+                       name='test ViewCoverage',
+                       parameter_dictionary=pdict)
+
+    return cov
 
 def samplecov2(save_coverage=False, in_memory=False, inline_data_writes=True):
     # Instantiate a ParameterDictionary

--- a/coverage_model/test/examples.py
+++ b/coverage_model/test/examples.py
@@ -326,8 +326,8 @@ def samplecov2(save_coverage=False, in_memory=False, inline_data_writes=True):
 
     # Add data for each parameter
     scov.set_parameter_values('time', value=np.arange(nt))
-    scov.set_parameter_values('lat', value=make_range_expr(45.32))
-    scov.set_parameter_values('lon', value=make_range_expr(-71.11))
+    scov.set_parameter_values('lat', value=45.32)
+    scov.set_parameter_values('lon', value=-71.11)
     # make a random sample of 10 values between 23 and 26
     # Ref: http://docs.scipy.org/doc/numpy/reference/generated/numpy.random.random_sample.html#numpy.random.random_sample
     # --> To sample  multiply the output of random_sample by (b-a) and add a

--- a/coverage_model/test/test_complex_coverage.py
+++ b/coverage_model/test/test_complex_coverage.py
@@ -7,9 +7,53 @@
 @brief Unit & Integration tests for ComplexCoverage
 """
 
+import os
 import numpy as np
 from coverage_model import *
 from nose.plugins.attrib import attr
+
+
+def _make_cov(root_dir, params, nt=10, data_dict=None):
+    # Construct temporal and spatial Coordinate Reference System objects
+    tcrs = CRS([AxisTypeEnum.TIME])
+    scrs = CRS([AxisTypeEnum.LON, AxisTypeEnum.LAT])
+
+    # Construct temporal and spatial Domain objects
+    tdom = GridDomain(GridShape('temporal', [0]), tcrs, MutabilityEnum.EXTENSIBLE) # 1d (timeline)
+    sdom = GridDomain(GridShape('spatial', [0]), scrs, MutabilityEnum.IMMUTABLE) # 0d spatial topology (station/trajectory)
+
+    if isinstance(params, ParameterDictionary):
+        pdict = params
+    else:
+        # Instantiate a ParameterDictionary
+        pdict = ParameterDictionary()
+
+        # Create a set of ParameterContext objects to define the parameters in the coverage, add each to the ParameterDictionary
+        t_ctxt = ParameterContext('time', param_type=QuantityType(value_encoding=np.dtype('int64')))
+        t_ctxt.uom = 'seconds since 01-01-1970'
+        pdict.add_context(t_ctxt, is_temporal=True)
+
+        for p in params:
+            if isinstance(p, ParameterContext):
+                pdict.add_context(p)
+            elif isinstance(params, tuple):
+                pdict.add_context(ParameterContext(p[0], param_type=QuantityType(value_encoding=np.dtype(p[1]))))
+            else:
+                pdict.add_context(ParameterContext(p, param_type=QuantityType(value_encoding=np.dtype('float32'))))
+
+    scov = SimplexCoverage(root_dir, create_guid(), 'sample coverage_model', parameter_dictionary=pdict, temporal_domain=tdom, spatial_domain=sdom)
+
+    scov.insert_timesteps(nt)
+    for p in scov.list_parameters():
+        if data_dict is not None and p in data_dict:
+            scov.set_parameter_values(p, data_dict[p])
+        else:
+            scov.set_parameter_values(p, range(nt))
+
+    scov.close()
+
+    return os.path.realpath(scov.persistence_dir)
+
 
 @attr('INT',group='cm')
 class TestComplexCoverageInt(CoverageModelIntTestCase):
@@ -20,64 +64,51 @@ class TestComplexCoverageInt(CoverageModelIntTestCase):
     def tearDown(self):
         pass
 
-    def _make_cov(self, params, nt=10):
-        # Construct temporal and spatial Coordinate Reference System objects
-        tcrs = CRS([AxisTypeEnum.TIME])
-        scrs = CRS([AxisTypeEnum.LON, AxisTypeEnum.LAT])
-
-        # Construct temporal and spatial Domain objects
-        tdom = GridDomain(GridShape('temporal', [0]), tcrs, MutabilityEnum.EXTENSIBLE) # 1d (timeline)
-        sdom = GridDomain(GridShape('spatial', [0]), scrs, MutabilityEnum.IMMUTABLE) # 0d spatial topology (station/trajectory)
-
-        if isinstance(params, ParameterDictionary):
-            pdict = params
-        else:
-            # Instantiate a ParameterDictionary
-            pdict = ParameterDictionary()
-
-            # Create a set of ParameterContext objects to define the parameters in the coverage, add each to the ParameterDictionary
-            t_ctxt = ParameterContext('time', param_type=QuantityType(value_encoding=np.dtype('int64')))
-            t_ctxt.uom = 'seconds since 01-01-1970'
-            pdict.add_context(t_ctxt, is_temporal=True)
-
-            for p in params:
-                if isinstance(p, ParameterContext):
-                    pdict.add_context(p)
-                elif isinstance(params, tuple):
-                    pdict.add_context(ParameterContext(p[0], param_type=QuantityType(value_encoding=np.dtype(p[1]))))
-                else:
-                    pdict.add_context(ParameterContext(p, param_type=QuantityType(value_encoding=np.dtype('float32'))))
-
-        scov = SimplexCoverage('test_data', create_guid(), 'sample coverage_model', parameter_dictionary=pdict, temporal_domain=tdom, spatial_domain=sdom)
-
-        scov.insert_timesteps(nt)
-        # scov.set_time_values('time', range(nt))
-        for p in scov.list_parameters(data_only=True):
-            scov.set_parameter_values(p, range(nt))
-
-        scov.close()
-
-        return scov.persistence_dir
-
     def test_parametric(self):
-        cova_pth = self._make_cov(['first_param'])
-        covb_pth = self._make_cov(['second_param'])
+        num_times = 10
+
+        first_data = np.arange(num_times, dtype='float32') * 0.2
+        second_data = np.random.random_sample(num_times) * (50 - 10) + 10
+        apple_data = np.arange(num_times, dtype='float32')
+        orange_data = np.arange(num_times, dtype='float32') * 2
+
+        cova_pth = _make_cov(self.working_dir, ['first_param'], data_dict={'first_param': first_data})
+        covb_pth = _make_cov(self.working_dir, ['second_param'], data_dict={'second_param': second_data})
+        covc_pth = _make_cov(self.working_dir, ['apples', 'oranges'], data_dict={'apples': apple_data, 'oranges': orange_data})
 
         # Instantiate a ParameterDictionary
         pdict = ParameterDictionary()
 
         # Create a set of ParameterContext objects to define the parameters in the coverage, add each to the ParameterDictionary
-        func = NumexprFunction('aXb', 'a*b', ['a', 'b'], {'a': 'first_param', 'b': 'second_param'})
-        val_ctxt = ParameterContext('aXb', param_type=ParameterFunctionType(function=func, value_encoding=np.dtype('float32')))
-        pdict.add_context(val_ctxt)
+        ab_func = NumexprFunction('aXb', 'a*b', ['a', 'b'], {'a': 'first_param', 'b': 'second_param'})
+        ab_ctxt = ParameterContext('aXb', param_type=ParameterFunctionType(function=ab_func, value_encoding=np.dtype('float32')))
+        pdict.add_context(ab_ctxt)
+
+        aplorng_func = NumexprFunction('apples_to_oranges', 'a*cos(sin(b))+c', ['a', 'b', 'c'], {'a': 'apples', 'b': 'oranges', 'c': 'first_param'})
+        aplorng_ctxt = ParameterContext('apples_to_oranges', param_type=ParameterFunctionType(function=aplorng_func, value_encoding=np.dtype('float32')))
+        pdict.add_context(aplorng_ctxt)
 
         # Instantiate the SimplexCoverage providing the ParameterDictionary, spatial Domain and temporal Domain
-        ccov = ComplexCoverage('test_data', 'test_complex', 'sample complex coverage', reference_coverages=[cova_pth, covb_pth], parameter_dictionary=pdict, complex_type=ComplexCoverageType.PARAMETRIC)
+        ccov = ComplexCoverage(self.working_dir, 'test_complex', 'sample complex coverage',
+                               reference_coverage_locs=[cova_pth, covb_pth, covc_pth],
+                               parameter_dictionary=pdict,
+                               complex_type=ComplexCoverageType.PARAMETRIC)
 
-        want = np.arange(10, dtype='float32')
-        self.assertTrue(np.array_equal(ccov.get_parameter_values('first_param'), want))
-        self.assertTrue(np.array_equal(ccov.get_parameter_values('second_param'), want))
+        self.assertEqual(ccov.list_parameters(),
+                         ['aXb', 'apples', 'apples_to_oranges', 'first_param', 'oranges', 'second_param', 'time'])
 
-        aXb_want = want * want
-        self.assertTrue(np.array_equal(ccov.get_parameter_values('aXb'), aXb_want))
+        self.assertEqual(ccov.temporal_parameter_name, 'time')
+        self.assertEqual(ccov.num_timesteps, num_times)
+
+        self.assertTrue(np.array_equal(ccov.get_parameter_values('first_param'), first_data))
+        self.assertTrue(np.allclose(ccov.get_parameter_values('second_param'), second_data))
+        self.assertTrue(np.array_equal(ccov.get_parameter_values('apples'), apple_data))
+        self.assertTrue(np.array_equal(ccov.get_parameter_values('oranges'), orange_data))
+
+        aXb_want = first_data * second_data
+        self.assertTrue(np.allclose(ccov.get_parameter_values('aXb'), aXb_want))
+        aplorng_want = apple_data * np.cos(np.sin(orange_data)) + first_data
+        self.assertTrue(np.allclose(ccov.get_parameter_values('apples_to_oranges'), aplorng_want))
+
+
 

--- a/coverage_model/test/test_complex_coverage.py
+++ b/coverage_model/test/test_complex_coverage.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python
+
+"""
+@package coverage_model.test.test_complex_coverage
+@file coverage_model/test/test_complex_coverage.py
+@author Christopher Mueller
+@brief Unit & Integration tests for ComplexCoverage
+"""
+
+import numpy as np
+from coverage_model import *
+from nose.plugins.attrib import attr
+
+@attr('INT',group='cm')
+class TestComplexCoverageInt(CoverageModelIntTestCase):
+
+    def setUp(self):
+        pass
+
+    def tearDown(self):
+        pass
+
+    def _make_cov(self, params, nt=10):
+        # Construct temporal and spatial Coordinate Reference System objects
+        tcrs = CRS([AxisTypeEnum.TIME])
+        scrs = CRS([AxisTypeEnum.LON, AxisTypeEnum.LAT])
+
+        # Construct temporal and spatial Domain objects
+        tdom = GridDomain(GridShape('temporal', [0]), tcrs, MutabilityEnum.EXTENSIBLE) # 1d (timeline)
+        sdom = GridDomain(GridShape('spatial', [0]), scrs, MutabilityEnum.IMMUTABLE) # 0d spatial topology (station/trajectory)
+
+        if isinstance(params, ParameterDictionary):
+            pdict = params
+        else:
+            # Instantiate a ParameterDictionary
+            pdict = ParameterDictionary()
+
+            # Create a set of ParameterContext objects to define the parameters in the coverage, add each to the ParameterDictionary
+            t_ctxt = ParameterContext('time', param_type=QuantityType(value_encoding=np.dtype('int64')))
+            t_ctxt.uom = 'seconds since 01-01-1970'
+            pdict.add_context(t_ctxt, is_temporal=True)
+
+            for p in params:
+                if isinstance(p, ParameterContext):
+                    pdict.add_context(p)
+                elif isinstance(params, tuple):
+                    pdict.add_context(ParameterContext(p[0], param_type=QuantityType(value_encoding=np.dtype(p[1]))))
+                else:
+                    pdict.add_context(ParameterContext(p, param_type=QuantityType(value_encoding=np.dtype('float32'))))
+
+        scov = SimplexCoverage('test_data', create_guid(), 'sample coverage_model', parameter_dictionary=pdict, temporal_domain=tdom, spatial_domain=sdom)
+
+        scov.insert_timesteps(nt)
+        # scov.set_time_values('time', range(nt))
+        for p in scov.list_parameters(data_only=True):
+            scov.set_parameter_values(p, range(nt))
+
+        scov.close()
+
+        return scov.persistence_dir
+
+    def test_parametric(self):
+        cova_pth = self._make_cov(['first_param'])
+        covb_pth = self._make_cov(['second_param'])
+
+        # Instantiate a ParameterDictionary
+        pdict = ParameterDictionary()
+
+        # Create a set of ParameterContext objects to define the parameters in the coverage, add each to the ParameterDictionary
+        func = NumexprFunction('aXb', 'a*b', ['a', 'b'], {'a': 'first_param', 'b': 'second_param'})
+        val_ctxt = ParameterContext('aXb', param_type=ParameterFunctionType(function=func, value_encoding=np.dtype('float32')))
+        pdict.add_context(val_ctxt)
+
+        # Instantiate the SimplexCoverage providing the ParameterDictionary, spatial Domain and temporal Domain
+        ccov = ComplexCoverage('test_data', 'test_complex', 'sample complex coverage', reference_coverages=[cova_pth, covb_pth], parameter_dictionary=pdict, complex_type=ComplexCoverageType.PARAMETRIC)
+
+        want = np.arange(10, dtype='float32')
+        self.assertTrue(np.array_equal(ccov.get_parameter_values('first_param'), want))
+        self.assertTrue(np.array_equal(ccov.get_parameter_values('second_param'), want))
+
+        aXb_want = want * want
+        self.assertTrue(np.array_equal(ccov.get_parameter_values('aXb'), aXb_want))
+

--- a/coverage_model/test/test_coverage_basics.py
+++ b/coverage_model/test/test_coverage_basics.py
@@ -179,8 +179,7 @@ class TestCoverageModelBasicsInt(CoverageModelIntTestCase):
         time_steps = 5000
         scov = self._create_multi_bricks_cov(brick_size, time_steps)
         self.assertIsInstance(scov, SimplexCoverage)
-        pl = scov._persistence_layer
-        self.assertTrue(pl.parameter_brick_count() == 5)
+        self.assertTrue(len(scov._persistence_layer.master_manager.brick_list) == 5)
 
     def test_create_succeeds(self):
         # Tests creation of SimplexCoverage succeeds

--- a/coverage_model/test/test_coverage_basics.py
+++ b/coverage_model/test/test_coverage_basics.py
@@ -626,7 +626,7 @@ class TestCoverageModelBasicsInt(CoverageModelIntTestCase):
     def test_persistence_variation5(self):
         scov = self._make_samplecov(in_memory=False, in_line=False, auto_flush=True, mode='a')
         cov_info_str = scov.info
-        self.assertIsInstance(cov_info_str, str)
+        self.assertIsInstance(cov_info_str, basestring)
 
     def test_run_test_dispatcher(self):
         from coverage_model.brick_dispatch import run_test_dispatcher

--- a/coverage_model/test/test_coverage_basics.py
+++ b/coverage_model/test/test_coverage_basics.py
@@ -180,7 +180,7 @@ class TestCoverageModelBasicsInt(CoverageModelIntTestCase):
         scov = self._create_multi_bricks_cov(brick_size, time_steps)
         self.assertIsInstance(scov, SimplexCoverage)
         pl = scov._persistence_layer
-        self.assertTrue(pl.parameter_brick_count('temp') == 5)
+        self.assertTrue(pl.parameter_brick_count() == 5)
 
     def test_create_succeeds(self):
         # Tests creation of SimplexCoverage succeeds

--- a/coverage_model/test/test_coverage_basics.py
+++ b/coverage_model/test/test_coverage_basics.py
@@ -17,24 +17,11 @@ import numpy as np
 from coverage_model import *
 from nose.plugins.attrib import attr
 
-TEST_DIR = os.path.join(tempfile.gettempdir(), 'cov_mdl_tests')
-
 @attr('INT', group='cov')
 class TestCoverageModelBasicsInt(CoverageModelIntTestCase):
 
-    @classmethod
-    def setUpClass(cls):
-        os.mkdir(TEST_DIR)
-
-    @classmethod
-    def tearDownClass(cls):
-        # Removes temporary files
-        # Comment this out if you need to inspect the HDF5 files.
-        shutil.rmtree(TEST_DIR)
-
     def setUp(self):
-        # Create temporary working directory for the persisted coverage tests
-        self.working_dir = TEST_DIR
+        pass
 
     # Loading Coverage Tests
     def test_load_succeeds(self):

--- a/coverage_model/test/test_parameter_functions.py
+++ b/coverage_model/test/test_parameter_functions.py
@@ -29,7 +29,7 @@ def _get_vals(name, slice_):
     else:
         return np.zeros(5)[slice_]
 
-@attr('UNIT',group='now')
+@attr('UNIT',group='cm')
 class TestParameterFunctionsUnit(CoverageModelUnitTestCase):
 
     def test_numexpr_function(self):
@@ -80,7 +80,7 @@ class TestParameterFunctionsUnit(CoverageModelUnitTestCase):
         self.assertTrue(np.array_equal(ret, np.array([1,  16,  81, 256, 625])))
 
 
-@attr('INT',group='now')
+@attr('INT',group='cm')
 class TestParameterFunctionsInt(CoverageModelIntTestCase):
 
     def setUp(self):
@@ -199,7 +199,7 @@ class TestParameterFunctionsInt(CoverageModelIntTestCase):
         self.assertTrue(np.allclose(rhoval[:], rho))
 
 import networkx as nx
-@attr('INT',group='now')
+@attr('INT',group='cm')
 class TestParameterValidatorInt(CoverageModelIntTestCase):
 
     def setUp(self):

--- a/coverage_model/test/test_parameter_values.py
+++ b/coverage_model/test/test_parameter_values.py
@@ -61,6 +61,7 @@ class TestParameterValuesUnit(cm.CoverageModelUnitTestCase):
             aval[x] = np.random.bytes(np.random.randint(1,20)) # One value (which is a byte string) for each member of the domain
 
         self.assertIsInstance(aval[0], np.ndarray)
+        self.assertIsInstance(aval[0][0], basestring)
         self.assertTrue(1 <= len(aval[0][0]) <= 20)
 
     # RecordType

--- a/coverage_model/test/test_utils.py
+++ b/coverage_model/test/test_utils.py
@@ -32,7 +32,7 @@ class TestUtilsUnit(CoverageModelUnitTestCase):
         guid = utils.create_guid()
 
         # Ensure the guid is a str
-        self.assertIsInstance(guid, str)
+        self.assertIsInstance(guid, basestring)
 
         # Make sure it's properly formatted - this also tests is_guid
         self.assertTrue(utils.is_guid(guid))


### PR DESCRIPTION
Goal is to reduce the number of files that must be modified when data is added to a coverage (in terms of updates to metadata).
- Moves brick-related metadata out of the parameter metadata files into the master metadata file.
- Expanding the domain now updates the master metadata file and does not iterate over all parameters
