### PR TITLE
Refactor hdf metadata

### DIFF
--- a/coverage_model/coverage.py
+++ b/coverage_model/coverage.py
@@ -1064,6 +1064,8 @@ class SimplexCoverage(AbstractCoverage):
                 # Must be in 'a' for a new coverage
                 self.mode = 'a'
 
+                insert_ts = 0
+
                 if not isinstance(name, basestring):
                     raise TypeError('\'name\' must be of type basestring')
                 self.name = name
@@ -1071,6 +1073,8 @@ class SimplexCoverage(AbstractCoverage):
                     self.temporal_domain = GridDomain(GridShape('temporal',[0]), CRS.standard_temporal(), MutabilityEnum.EXTENSIBLE)
                 elif isinstance(temporal_domain, AbstractDomain):
                     self.temporal_domain = deepcopy(temporal_domain)
+                    insert_ts = self.temporal_domain.shape.extents[0]
+                    self.temporal_domain.shape.extents = (0,) + tuple(self.temporal_domain.shape.extents[1:])
                 else:
                     raise TypeError('\'temporal_domain\' must be an instance of AbstractDomain')
 
@@ -1095,6 +1099,9 @@ class SimplexCoverage(AbstractCoverage):
 
                 for o, pc in parameter_dictionary.itervalues():
                     self.append_parameter(pc)
+
+                if insert_ts != 0:
+                    self.insert_timesteps(insert_ts)
         except:
             self._closed = True
             raise

--- a/coverage_model/coverage.py
+++ b/coverage_model/coverage.py
@@ -1022,12 +1022,13 @@ class SimplexCoverage(AbstractCoverage):
                 from coverage_model.persistence import PersistedStorage
                 for parameter_name in self._persistence_layer.parameter_metadata.keys():
                     md = self._persistence_layer.parameter_metadata[parameter_name]
+                    mm = self._persistence_layer.master_manager
                     pc = md.parameter_context
                     if hasattr(pc, '_pval_callback'):
                         pc._pval_callback = self.get_parameter_values
                         pc._pctxt_callback = self.get_parameter_context
                     self._range_dictionary.add_context(pc)
-                    s = PersistedStorage(md, self._persistence_layer.brick_dispatcher, dtype=pc.param_type.storage_encoding, fill_value=pc.param_type.fill_value, mode=self.mode, inline_data_writes=inline_data_writes, auto_flush=auto_flush_values)
+                    s = PersistedStorage(md, mm, self._persistence_layer.brick_dispatcher, dtype=pc.param_type.storage_encoding, fill_value=pc.param_type.fill_value, mode=self.mode, inline_data_writes=inline_data_writes, auto_flush=auto_flush_values)
                     self._range_value[parameter_name] = get_value_class(param_type=pc.param_type, domain_set=pc.dom, storage=s)
                     if parameter_name in self._persistence_layer.parameter_bounds:
                         bmin, bmax = self._persistence_layer.parameter_bounds[parameter_name]

--- a/coverage_model/coverage.py
+++ b/coverage_model/coverage.py
@@ -163,14 +163,10 @@ class AbstractCoverage(AbstractIdentifiable):
         # Expand the shape of the temporal_domain - following works if extents is a list or tuple
         shp.extents = (shp.extents[0]+count,)+tuple(shp.extents[1:])
 
+        self._persistence_layer.expand_domain(shp.extents)
+
         # Expand the temporal dimension of each of the parameters - the parameter determines how to apply the change
         for n in self._range_dictionary:
-            pc = self._range_dictionary.get_context(n)
-            # Update the dom of the parameter_context
-            # if pc.dom.tdom is not None:
-            #     pc.dom.tdom = self.temporal_domain.shape.extents
-            if pc.name == 'time':
-                self._persistence_layer.expand_domain(pc)
             self._range_value[n].expand_content(VariabilityEnum.TEMPORAL, origin, count)
 
         # Update the temporal_domain in the master_manager, do NOT flush!!

--- a/coverage_model/coverage.py
+++ b/coverage_model/coverage.py
@@ -169,8 +169,8 @@ class AbstractCoverage(AbstractIdentifiable):
             # Update the dom of the parameter_context
             # if pc.dom.tdom is not None:
             #     pc.dom.tdom = self.temporal_domain.shape.extents
-
-            self._persistence_layer.expand_domain(pc)
+            if pc.name == 'time':
+                self._persistence_layer.expand_domain(pc)
             self._range_value[n].expand_content(VariabilityEnum.TEMPORAL, origin, count)
 
         # Update the temporal_domain in the master_manager, do NOT flush!!

--- a/coverage_model/persistence.py
+++ b/coverage_model/persistence.py
@@ -218,7 +218,7 @@ class PersistenceLayer(object):
 
         self.global_bricking_scheme = bricking_scheme
 
-        pm = ParameterManager(os.path.join(self.root_dir, self.guid, parameter_name), parameter_name)
+        pm = ParameterManager(os.path.join(self.root_dir, self.guid, parameter_name), parameter_name, read_only=False)
         self.parameter_metadata[parameter_name] = pm
 
         pm.parameter_context = parameter_context
@@ -259,6 +259,10 @@ class PersistenceLayer(object):
         # CBM TODO: Consider making this optional and bulk-flushing from the coverage after all parameters have been initialized
         # No need to check if they're dirty, we know they are!
         pm.flush()
+
+        # Put the pm into read_only mode
+        pm.read_only = True
+
         self.master_manager.flush()
 
         return v

--- a/coverage_model/persistence_helpers.py
+++ b/coverage_model/persistence_helpers.py
@@ -146,6 +146,9 @@ class MasterManager(BaseManager):
 
             self.param_groups = set()
             f.visit(self.param_groups.add)
+            log.warn('self.param_groups: %s', self.param_groups)
+            # TODO: Use valid parameter list to compare against inspected param_groups and discard all that are invalid
+            self.param_groups.discard('rtree')
 
             # Don't forget brick_tree!
             p = rtree.index.Property()

--- a/coverage_model/persistence_helpers.py
+++ b/coverage_model/persistence_helpers.py
@@ -128,11 +128,11 @@ class MasterManager(BaseManager):
             self.param_groups = set()
 
     def update_rtree(self, count, extents, obj):
-        log.warn('MM count: {0}'.format(count))
+        log.debug('MM count: {0}'.format(count))
         if not hasattr(self, 'brick_tree'):
             raise AttributeError('Cannot update rtree; object does not have a \'brick_tree\' attribute!!')
 
-        log.warn('self.file_path: {0}'.format(self.file_path))
+        log.debug('self.file_path: {0}'.format(self.file_path))
         with h5py.File(self.file_path, 'a') as f:
             rtree_ds = f.require_dataset('rtree', shape=(count,), dtype=h5py.special_dtype(vlen=str), maxshape=(None,))
             rtree_ds.resize((count+1,))

--- a/coverage_model/persistence_helpers.py
+++ b/coverage_model/persistence_helpers.py
@@ -175,15 +175,20 @@ class MasterManager(BaseManager):
 
 class ParameterManager(BaseManager):
 
-    def __init__(self, root_dir, parameter_name, **kwargs):
+    def __init__(self, root_dir, parameter_name, read_only=True, **kwargs):
         BaseManager.__init__(self, root_dir=root_dir, file_name='{0}.hdf5'.format(parameter_name), **kwargs)
         self.parameter_name = parameter_name
+        self.read_only = read_only
 
         # Add attributes that should NEVER be flushed
         self._ignore.update(['brick_tree', 'file_path', 'root_dir'])
 
     def thin_origins(self, origins):
         pass
+
+    def flush(self):
+        if not self.read_only:
+            super(ParameterManager, self).flush()
 
     # def update_rtree(self, count, extents, obj):
     #     log.warn('PM [{1}] count: {0}'.format(count, self.parameter_name))

--- a/coverage_model/persistence_helpers.py
+++ b/coverage_model/persistence_helpers.py
@@ -134,7 +134,7 @@ class MasterManager(BaseManager):
 
         log.warn('self.file_path: {0}'.format(self.file_path))
         with h5py.File(self.file_path, 'a') as f:
-            rtree_ds = f.require_dataset('rtree', shape=(1,), dtype=h5py.special_dtype(vlen=str), maxshape=(None,))
+            rtree_ds = f.require_dataset('rtree', shape=(count,), dtype=h5py.special_dtype(vlen=str), maxshape=(None,))
             rtree_ds.resize((count+1,))
             rtree_ds[count] = pack((extents, obj))
 
@@ -185,35 +185,35 @@ class ParameterManager(BaseManager):
     def thin_origins(self, origins):
         pass
 
-    def update_rtree(self, count, extents, obj):
-        log.warn('PM [{1}] count: {0}'.format(count, self.parameter_name))
-        if not hasattr(self, 'brick_tree'):
-            raise AttributeError('Cannot update rtree; object does not have a \'brick_tree\' attribute!!')
-
-        with h5py.File(self.file_path, 'a') as f:
-            rtree_ds = f.require_dataset('rtree', shape=(count,), dtype=h5py.special_dtype(vlen=str), maxshape=(None,))
-            rtree_ds.resize((count+1,))
-            rtree_ds[count] = pack((extents, obj))
-
-            self.brick_tree.insert(count, extents, obj=obj)
+    # def update_rtree(self, count, extents, obj):
+    #     log.warn('PM [{1}] count: {0}'.format(count, self.parameter_name))
+    #     if not hasattr(self, 'brick_tree'):
+    #         raise AttributeError('Cannot update rtree; object does not have a \'brick_tree\' attribute!!')
+    #
+    #     with h5py.File(self.file_path, 'a') as f:
+    #         rtree_ds = f.require_dataset('rtree', shape=(count,), dtype=h5py.special_dtype(vlen=str), maxshape=(None,))
+    #         rtree_ds.resize((count+1,))
+    #         rtree_ds[count] = pack((extents, obj))
+    #
+    #         self.brick_tree.insert(count, extents, obj=obj)
 
     def _load(self):
         with h5py.File(self.file_path, 'r') as f:
             self._base_load(f)
 
-            # Don't forget brick_tree!
-            p = rtree.index.Property()
-            p.dimension = self.tree_rank
-
-            if 'rtree' in f.keys():
-                # Populate brick tree from the 'rtree' dataset
-                ds = f['/rtree']
-
-                def tree_loader(darr):
-                    for i, x in enumerate(darr):
-                        ext, obj = unpack(x)
-                        yield (i, ext, obj)
-
-                setattr(self, 'brick_tree', rtree.index.Index(tree_loader(ds[:]), properties=p))
-            else:
-                setattr(self, 'brick_tree', rtree.index.Index(properties=p))
+            # # Don't forget brick_tree!
+            # p = rtree.index.Property()
+            # p.dimension = self.tree_rank
+            #
+            # if 'rtree' in f.keys():
+            #     # Populate brick tree from the 'rtree' dataset
+            #     ds = f['/rtree']
+            #
+            #     def tree_loader(darr):
+            #         for i, x in enumerate(darr):
+            #             ext, obj = unpack(x)
+            #             yield (i, ext, obj)
+            #
+            #     setattr(self, 'brick_tree', rtree.index.Index(tree_loader(ds[:]), properties=p))
+            # else:
+            #     setattr(self, 'brick_tree', rtree.index.Index(properties=p))

--- a/coverage_model/persistence_helpers.py
+++ b/coverage_model/persistence_helpers.py
@@ -87,6 +87,7 @@ class BaseManager(object):
 
             if isinstance(value, tuple):
                 value = list(value)
+
             setattr(self, key, value)
 
     def is_dirty(self, force_deep=False):
@@ -146,7 +147,6 @@ class MasterManager(BaseManager):
 
             self.param_groups = set()
             f.visit(self.param_groups.add)
-            log.warn('self.param_groups: %s', self.param_groups)
             # TODO: Use valid parameter list to compare against inspected param_groups and discard all that are invalid
             self.param_groups.discard('rtree')
 
@@ -193,35 +193,7 @@ class ParameterManager(BaseManager):
         if not self.read_only:
             super(ParameterManager, self).flush()
 
-    # def update_rtree(self, count, extents, obj):
-    #     log.warn('PM [{1}] count: {0}'.format(count, self.parameter_name))
-    #     if not hasattr(self, 'brick_tree'):
-    #         raise AttributeError('Cannot update rtree; object does not have a \'brick_tree\' attribute!!')
-    #
-    #     with h5py.File(self.file_path, 'a') as f:
-    #         rtree_ds = f.require_dataset('rtree', shape=(count,), dtype=h5py.special_dtype(vlen=str), maxshape=(None,))
-    #         rtree_ds.resize((count+1,))
-    #         rtree_ds[count] = pack((extents, obj))
-    #
-    #         self.brick_tree.insert(count, extents, obj=obj)
-
     def _load(self):
         with h5py.File(self.file_path, 'r') as f:
             self._base_load(f)
 
-            # # Don't forget brick_tree!
-            # p = rtree.index.Property()
-            # p.dimension = self.tree_rank
-            #
-            # if 'rtree' in f.keys():
-            #     # Populate brick tree from the 'rtree' dataset
-            #     ds = f['/rtree']
-            #
-            #     def tree_loader(darr):
-            #         for i, x in enumerate(darr):
-            #             ext, obj = unpack(x)
-            #             yield (i, ext, obj)
-            #
-            #     setattr(self, 'brick_tree', rtree.index.Index(tree_loader(ds[:]), properties=p))
-            # else:
-            #     setattr(self, 'brick_tree', rtree.index.Index(properties=p))

--- a/coverage_model/test/examples.py
+++ b/coverage_model/test/examples.py
@@ -326,8 +326,8 @@ def samplecov2(save_coverage=False, in_memory=False, inline_data_writes=True):
 
     # Add data for each parameter
     scov.set_parameter_values('time', value=np.arange(nt))
-    scov.set_parameter_values('lat', value=make_range_expr(45.32))
-    scov.set_parameter_values('lon', value=make_range_expr(-71.11))
+    scov.set_parameter_values('lat', value=45.32)
+    scov.set_parameter_values('lon', value=-71.11)
     # make a random sample of 10 values between 23 and 26
     # Ref: http://docs.scipy.org/doc/numpy/reference/generated/numpy.random.random_sample.html#numpy.random.random_sample
     # --> To sample  multiply the output of random_sample by (b-a) and add a

--- a/coverage_model/test/test_coverage_basics.py
+++ b/coverage_model/test/test_coverage_basics.py
@@ -179,8 +179,7 @@ class TestCoverageModelBasicsInt(CoverageModelIntTestCase):
         time_steps = 5000
         scov = self._create_multi_bricks_cov(brick_size, time_steps)
         self.assertIsInstance(scov, SimplexCoverage)
-        pl = scov._persistence_layer
-        self.assertTrue(pl.parameter_brick_count() == 5)
+        self.assertTrue(len(scov._persistence_layer.master_manager.brick_list) == 5)
 
     def test_create_succeeds(self):
         # Tests creation of SimplexCoverage succeeds

--- a/coverage_model/test/test_coverage_basics.py
+++ b/coverage_model/test/test_coverage_basics.py
@@ -180,7 +180,7 @@ class TestCoverageModelBasicsInt(CoverageModelIntTestCase):
         scov = self._create_multi_bricks_cov(brick_size, time_steps)
         self.assertIsInstance(scov, SimplexCoverage)
         pl = scov._persistence_layer
-        self.assertTrue(pl.parameter_brick_count('temp') == 5)
+        self.assertTrue(pl.parameter_brick_count() == 5)
 
     def test_create_succeeds(self):
         # Tests creation of SimplexCoverage succeeds


### PR DESCRIPTION
Goal is to reduce the number of files that must be modified when data is added to a coverage (in terms of updates to metadata).
- Moves brick-related metadata out of the parameter metadata files into the master metadata file.
- Expanding the domain now updates the master metadata file and does not iterate over all parameters
