### PR TITLE
Ensures PersistedStorage returns either atleast_1d or scalar

### DIFF
--- a/coverage_model/persistence.py
+++ b/coverage_model/persistence.py
@@ -668,14 +668,11 @@ class PersistedStorage(AbstractStorage):
 
                 ret_arr[ret_slice] = ret_vals
 
-        ret_arr = ret_arr.squeeze()
+        ret_arr = np.atleast_1d(ret_arr.squeeze())
 
         # If the array is size 1 AND a slice object was NOT part of the query
         if ret_arr.size == 1 and not np.atleast_1d([isinstance(s, slice) for s in slice_]).all():
-            if ret_arr.ndim == 0:
-                ret_arr = ret_arr[()]
-            else:
-                ret_arr = ret_arr[0]
+            ret_arr = ret_arr[0]
 
         return ret_arr
 


### PR DESCRIPTION
Makes certain that the value(s) returned by the PersistedStorage are either a scalar value or at least a 1d numpy array

Also adds interop parameter_values test for category value
