### PR TITLE
Improves coverage load mechanism; minor fixes

### DIFF
--- a/coverage_model/__init__.py
+++ b/coverage_model/__init__.py
@@ -1,6 +1,6 @@
 from basic_types import AxisTypeEnum, MutabilityEnum, VariabilityEnum
-from coverage import SimplexCoverage, ViewCoverage, ComplexCoverage, ComplexCoverageType, SimpleDomainSet, GridDomain, \
-    GridShape, CRS
+from coverage import AbstractCoverage, SimplexCoverage, ViewCoverage, ComplexCoverage, ComplexCoverageType, \
+    SimpleDomainSet, GridDomain, GridShape, CRS
 from coverage_model.parameter_functions import PythonFunction, NumexprFunction
 from parameter import ParameterContext, ParameterDictionary, ParameterFunctionValidator
 from parameter_types import ArrayType, BooleanType, CategoryRangeType, CategoryType, ConstantType, CountRangeType, \
@@ -12,19 +12,62 @@ from utils import create_guid, fix_slice
 from numexpr_utils import make_range_expr
 from coverage_model.base_test_cases import CoverageModelUnitTestCase, CoverageModelIntTestCase
 
-_core = ['ParameterContext', 'ParameterDictionary', 'ParameterFunctionValidator', 'SimplexCoverage', 'ViewCoverage',
-         'ComplexCoverage', 'ComplexCoverageType', 'SimpleDomainSet', 'GridDomain', 'GridShape', 'CRS', 'AxisTypeEnum',
-         'MutabilityEnum', 'VariabilityEnum']
+_core = [
+    'ParameterContext',
+    'ParameterDictionary',
+    'ParameterFunctionValidator',
+    'AbstractCoverage',
+    'SimplexCoverage',
+    'ViewCoverage',
+    'ComplexCoverage',
+    'ComplexCoverageType',
+    'SimpleDomainSet',
+    'GridDomain',
+    'GridShape',
+    'CRS',
+    'AxisTypeEnum',
+    'MutabilityEnum',
+    'VariabilityEnum',
+    ]
 
-_types = ['ArrayType', 'BooleanType', 'CategoryRangeType', 'CategoryType', 'ConstantType', 'CountRangeType',
-          'CountType', 'FunctionType', 'QuantityRangeType', 'QuantityType', 'RecordType', 'ReferenceType', 'TextType',
-          'TimeRangeType', 'TimeType', 'VectorType', 'ConstantRangeType', 'ParameterFunctionType']
+_types = [
+    'ArrayType',
+    'BooleanType',
+    'CategoryRangeType',
+    'CategoryType',
+    'ConstantType',
+    'CountRangeType',
+    'CountType',
+    'FunctionType',
+    'QuantityRangeType',
+    'QuantityType',
+    'RecordType',
+    'ReferenceType',
+    'TextType',
+    'TimeRangeType',
+    'TimeType',
+    'VectorType',
+    'ConstantRangeType',
+    'ParameterFunctionType',
+    ]
 
-_functions = ['NumexprFunction', 'PythonFunction']
+_functions = [
+    'NumexprFunction',
+    'PythonFunction',
+    ]
 
-_utils = ['utils', 'make_range_expr', 'create_guid', 'get_value_class', 'fix_slice']
+_utils = [
+    'utils',
+    'make_range_expr',
+    'create_guid',
+    'get_value_class',
+    'fix_slice',
+    ]
 
-_test_cases = ['CoverageModelUnitTestCase', 'CoverageModelIntTestCase']
+_test_cases = [
+    'CoverageModelUnitTestCase',
+    'CoverageModelIntTestCase',
+    ]
 
 # Determines the set of things imported by using:  from coverage_model import *
 __all__ = _core + _types + _utils + _functions + _test_cases

--- a/coverage_model/basic_types.py
+++ b/coverage_model/basic_types.py
@@ -374,7 +374,8 @@ class NdSpan(AbstractBase):
     def __len__(self):
         return prod(self.shape)
 
-
+import functools
+@functools.total_ordering
 class Span(AbstractBase):
 
     def __init__(self, lower_bound=None, upper_bound=None, value=None):
@@ -427,13 +428,23 @@ class Span(AbstractBase):
 
     def __eq__(self, other):
         if isinstance(other, Span):
-            if self.upper_bound == other.upper_bound and self.lower_bound == other.upper_bound:
+            if self.upper_bound == other.upper_bound and self.lower_bound == other.lower_bound:
                 return True
 
         return False
 
     def __ne__(self, other):
         return not self == other
+
+    def __lt__(self, other):
+        if isinstance(other, Span):
+            if self.lower_bound is None:
+                return True
+
+            if self.lower_bound < other.lower_bound:
+                return True
+
+        return False
 
     def __len__(self):
         if self.lower_bound is not None and self.upper_bound is not None:

--- a/coverage_model/persistence.py
+++ b/coverage_model/persistence.py
@@ -24,10 +24,11 @@ class PersistenceError(Exception):
 
 class SimplePersistenceLayer(object):
 
-    def __init__(self, root, guid, name=None, param_dict=None, mode=None, **kwargs):
+    def __init__(self, root, guid, name=None, param_dict=None, mode=None, coverage_type='simplex', **kwargs):
         root = '.' if root is ('' or None) else root
 
-        self.master_manager = MasterManager(root_dir=root, guid=guid, name=name, param_dict=param_dict, parameter_bounds=None, **kwargs)
+        self.master_manager = MasterManager(root_dir=root, guid=guid, name=name, param_dict=param_dict,
+                                            parameter_bounds=None, tree_rank=2, coverage_type=coverage_type, **kwargs)
 
         self.mode = mode
 
@@ -93,7 +94,7 @@ class PersistenceLayer(object):
     The PersistenceLayer class manages the disk-level storage (and retrieval) of the Coverage Model using HDF5 files.
     """
 
-    def __init__(self, root, guid, name=None, tdom=None, sdom=None, mode=None, bricking_scheme=None, inline_data_writes=True, auto_flush_values=True, value_caching=True, **kwargs):
+    def __init__(self, root, guid, name=None, tdom=None, sdom=None, mode=None, bricking_scheme=None, inline_data_writes=True, auto_flush_values=True, value_caching=True, coverage_type='simplex', **kwargs):
         """
         Constructor for PersistenceLayer
 
@@ -112,7 +113,7 @@ class PersistenceLayer(object):
         log.debug('Persistence GUID: %s', guid)
         root = '.' if root is ('' or None) else root
 
-        self.master_manager = MasterManager(root, guid, name=name, tdom=tdom, sdom=sdom, global_bricking_scheme=bricking_scheme, parameter_bounds=None)
+        self.master_manager = MasterManager(root, guid, name=name, tdom=tdom, sdom=sdom, global_bricking_scheme=bricking_scheme, parameter_bounds=None, coverage_type=coverage_type)
 
         self.mode = mode
         if not hasattr(self.master_manager, 'auto_flush_values'):

--- a/coverage_model/persistence_helpers.py
+++ b/coverage_model/persistence_helpers.py
@@ -21,8 +21,20 @@ import msgpack
 def pack(payload):
     return msgpack.packb(payload, default=encode_ion).replace('\x01','\x01\x02').replace('\x00','\x01\x01')
 
+
 def unpack(msg):
     return msgpack.unpackb(msg.replace('\x01\x01','\x00').replace('\x01\x02','\x01'), object_hook=decode_ion)
+
+
+def get_coverage_type(path):
+    ctype = 'simplex'
+    if os.path.exists(path):
+        with h5py.File(path) as f:
+            if 'coverage_type' in f.attrs:
+                ctype = unpack(f.attrs['coverage_type'])
+
+    return ctype
+
 
 class BaseManager(object):
 
@@ -72,7 +84,7 @@ class BaseManager(object):
 
     def _base_load(self, f):
         for key, val in f.attrs.iteritems():
-            if val.startswith('DICTABLE'):
+            if isinstance(val, basestring) and val.startswith('DICTABLE'):
                 i = val.index('|', 9)
                 smod, sclass = val[9:i].split(':')
                 value = unpack(val[i+1:])


### PR DESCRIPTION
Improves the .load function for coverages such that *Coverage.load will load the correct coverage based on the .coverage_type attribute regardless of the abstract/concrete used (i.e. AbstractCoverage.load & SimplexCoverage.load will result in the same type of coverage - even if it's a ViewCoverage!!)

Exposes AbstractCoverage in coverage_model/**init**.py

Provides full comparison functionality (via functools.total_ordering) for Span objects
