### PR TITLE
Cm tests update

### DIFF
--- a/coverage_model/test/coverage_test_base.py
+++ b/coverage_model/test/coverage_test_base.py
@@ -300,39 +300,41 @@ class CoverageIntTestBase(object):
     # ############################
     # LOADING
     def test_load_init_succeeds(self):
-        # Creates a valid coverage, inserts data and loads coverage back up from the HDF5 files.
+        # Creates a valid coverage and loads coverage back up from the HDF5 files.
         scov, cov_name = self.get_cov()
-        self._insert_set_get(scov=scov, timesteps=50, data=np.arange(50), _slice=slice(0,50), param='time')
         pl = scov._persistence_layer
         guid = scov.persistence_guid
         root_path = pl.master_manager.root_dir
         base_path = root_path.replace(guid,'')
         scov.close()
-        lcov = SimplexCoverage(base_path, guid)
-        self.assertIsInstance(lcov, AbstractCoverage)
 
-        lcov = SimplexCoverage.load(scov.persistence_dir)
+        lcov = SimplexCoverage(base_path, guid)
         self.assertIsInstance(lcov, AbstractCoverage)
         lcov.close()
 
     def test_dot_load_succeeds(self):
-        # Creates a valid coverage, inserts data and .load coverage back up from the HDF5 files.
+        # Creates a valid coverage and .load coverage back up from the HDF5 files.
         scov, cov_name = self.get_cov()
-        self._insert_set_get(scov=scov, timesteps=50, data=np.arange(50), _slice=slice(0,50), param='time')
         pl = scov._persistence_layer
         guid = scov.persistence_guid
         root_path = pl.master_manager.root_dir
         base_path = root_path.replace(guid,'')
         scov.close()
+
         lcov = SimplexCoverage.load(base_path, guid)
         lcov.close()
         self.assertIsInstance(lcov, AbstractCoverage)
+        lcov.close()
+
+        acov = AbstractCoverage.load(base_path, guid)
+        acov.close()
+        self.assertIsInstance(acov, AbstractCoverage)
+        acov.close()
 
     def test_get_data_after_load(self):
         # Creates a valid coverage, inserts data and .load coverage back up from the HDF5 files.
         results =[]
         scov, cov_name = self.get_cov(nt=50)
-        # self._insert_set_get(scov=scov, timesteps=50, data=np.arange(50), _slice=slice(0,50), param='time')
         pl = scov._persistence_layer
         guid = scov.persistence_guid
         root_path = pl.master_manager.root_dir

--- a/coverage_model/test/test_simplex_coverage.py
+++ b/coverage_model/test/test_simplex_coverage.py
@@ -355,47 +355,14 @@ class TestPtypesCovInt(CoverageModelIntTestCase, CoverageIntTestBase):
         return scov, 'TestPtypesCovInt'
 
     def _insert_set_get(self, scov=None, timesteps=None, data=None, _slice=None, param='all'):
-        return True
-        # # Function to test variable occurances of getting and setting values across parameter(s)
-        # data = data[_slice]
-        # ret = []
-        #
-        # scov.insert_timesteps(timesteps)
-        #
-        # scov.set_parameter_values('time', value=data, slice=_slice)
-        # if param == 'all':
-        #     scov.set_parameter_values('boolean', value=[True, True, True], tdoa=[[2,4,14]])
-        #     scov.set_parameter_values('const_float', value=-71.11) # Set a constant with correct data type
-        #     scov.set_parameter_values('const_int', value=45.32) # Set a constant with incorrect data type (fixed under the hood)
-        #     scov.set_parameter_values('const_str', value='constant string value') # Set with a string
-        #     scov.set_parameter_values('const_rng_flt', value=(12.8, 55.2)) # Set with a tuple
-        #     scov.set_parameter_values('const_rng_int', value=[-10, 10]) # Set with a list
-        #
-        #     scov.set_parameter_values('quantity', value=np.random.random_sample(nt)*(26-23)+23, slice=_slice)
-        #
-        #     arrval = []
-        #     recval = []
-        #     catval = []
-        #     fstrval = []
-        #     catkeys = EXEMPLAR_CATEGORIES.keys()
-        #     letts='abcdefghijklmnopqrstuvwxyz'
-        #     while len(letts) < nt:
-        #         letts += 'abcdefghijklmnopqrstuvwxyz'
-        #     for x in xrange(nt):
-        #         arrval.append(np.random.bytes(np.random.randint(1,20))) # One value (which is a byte string) for each member of the domain
-        #         d = {letts[x]: letts[x:]}
-        #         recval.append(d) # One value (which is a dict) for each member of the domain
-        #         catval.append(random.choice(catkeys))
-        #         fstrval.append(''.join([random.choice(letts) for x in xrange(8)])) # A random string of length 8
-        #     scov.set_parameter_values('array', value=arrval)
-        #     scov.set_parameter_values('record', value=recval)
-        #     scov.set_parameter_values('category', value=catval)
-        #     scov.set_parameter_values('fixed_str', value=fstrval)
-        #
-        # #TODO: Loop over all parameters?????
-        # ret = scov.get_parameter_values('time', slice=_slice)
-        #
-        # return (ret == data).all()
+        # TODO: Only tests time parameter so far.
+        param = 'time'
+        data = data[_slice]
+        scov.insert_timesteps(timesteps)
+        scov.set_parameter_values(param, data, _slice)
+        scov.get_dirty_values_async_result().get(timeout=60)
+        ret = scov.get_parameter_values(param, _slice)
+        return (ret == data).all()
 
     def test_ptypescov_get_values(self):
         # Tests retrieval of values from QuantityType, ConstantType,

--- a/coverage_model/test/test_view_coverage.py
+++ b/coverage_model/test/test_view_coverage.py
@@ -84,18 +84,6 @@ class TestSampleCovViewInt(CoverageModelIntTestCase, CoverageIntTestBase):
         self.assertEqual(vcov2.head_coverage_path, cov1.persistence_dir)
 
     @unittest.skip('Does not apply to ViewCoverage.')
-    def test_load_init_succeeds(self):
-        pass
-
-    @unittest.skip('Does not apply to ViewCoverage.')
-    def test_load_succeeds_with_options(self):
-        pass
-
-    @unittest.skip('Does not apply to ViewCoverage.')
-    def test_dot_load_succeeds(self):
-        pass
-
-    @unittest.skip('Does not apply to ViewCoverage.')
     def test_set_time_one_brick(self):
         pass
 


### PR DESCRIPTION
Removes duplication of init and .load coverage loading.
Adds check for AbstractCoverage.load
Changes behavior of _insert_set_get for ptypescov.
