### PR TITLE
Temporal interleaved & bug fixes

### DIFF
--- a/coverage_model/__init__.py
+++ b/coverage_model/__init__.py
@@ -1,4 +1,4 @@
-from basic_types import AxisTypeEnum, MutabilityEnum, VariabilityEnum
+from basic_types import AxisTypeEnum, MutabilityEnum, VariabilityEnum, Span
 from coverage import AbstractCoverage, SimplexCoverage, ViewCoverage, ComplexCoverage, ComplexCoverageType, \
     SimpleDomainSet, GridDomain, GridShape, CRS
 from coverage_model.parameter_functions import PythonFunction, NumexprFunction
@@ -28,6 +28,7 @@ _core = [
     'AxisTypeEnum',
     'MutabilityEnum',
     'VariabilityEnum',
+    'Span',
     ]
 
 _types = [

--- a/coverage_model/coverage.py
+++ b/coverage_model/coverage.py
@@ -140,7 +140,7 @@ class AbstractCoverage(AbstractIdentifiable):
         cov_obj.flush()
 
     def refresh(self):
-        if not hasattr(self, '_in_memory_storage'):
+        if not hasattr(self, '_in_memory_storage') or not self._in_memory_storage:
             self.close()
             self.__init__(os.path.split(self.persistence_dir)[0], self.persistence_guid, mode=self.mode)
 

--- a/coverage_model/coverage.py
+++ b/coverage_model/coverage.py
@@ -934,6 +934,8 @@ class ComplexCoverage(AbstractCoverage):
     """
     def __init__(self, root_dir, persistence_guid, name=None, reference_coverage_locs=None, parameter_dictionary=None,
                  mode=None, complex_type=ComplexCoverageType.PARAMETRIC_STRICT, temporal_domain=None, spatial_domain=None):
+
+        # Should always be in WRITE mode because we do domain work when setting up
         AbstractCoverage.__init__(self, mode='w')
 
         try:
@@ -953,7 +955,7 @@ class ComplexCoverage(AbstractCoverage):
 
                 self.name = self._persistence_layer.name
 
-                self.mode = mode
+                self.mode = self.mode
 
                 self._reference_covs = {}
 

--- a/coverage_model/coverage.py
+++ b/coverage_model/coverage.py
@@ -962,12 +962,12 @@ class ComplexCoverage(AbstractCoverage):
                 self._dobuild(self._persistence_layer.complex_type,
                               reference_coverages=self._persistence_layer.rcov_locs,
                               parameter_dictionary=self._persistence_layer.param_dict)
-            # if reference_coverage_locs is None or name is None or parameter_dictionary is None:
+
             if os.path.exists(pth):
                 _doload(self)
             else:
-                if reference_coverage_locs is None or name is None or parameter_dictionary is None:
-                    raise SystemError('\'reference_coverages\', \'name\' and \'parameter_dictionary\' cannot be None')
+                if reference_coverage_locs is None or name is None:
+                    raise SystemError('\'reference_coverages\' and \'name\' cannot be None')
 
                 # If the coverage directory exists, load it instead!!
                 if os.path.exists(pth):
@@ -978,6 +978,9 @@ class ComplexCoverage(AbstractCoverage):
                 if not isinstance(name, basestring):
                     raise TypeError('\'name\' must be of type basestring')
                 self.name = name
+
+                if parameter_dictionary is None:
+                    parameter_dictionary = ParameterDictionary()
 
                 # Must be in 'a' for a new coverage
                 self.mode = 'a'

--- a/coverage_model/coverage.py
+++ b/coverage_model/coverage.py
@@ -1125,11 +1125,14 @@ class ComplexCoverage(AbstractCoverage):
             self._reference_covs[cpth] = cov
 
             # Add parameters from the coverage if not already present
-            for p in cov.list_parameters():
+            covpd = cov.parameter_dictionary # Provides a copy
+            for p, pc in covpd.iteritems():
                 if p not in parameter_dictionary:
                     if p not in self._range_dictionary:
                         # Add the context from the reference coverage
-                        self._range_dictionary.add_context(self._reference_covs[cpth]._range_dictionary.get_context(p))
+                        pc = pc[1]  # pc is a tuple (ordinal, ParameterContext)
+                        self._assign_domain(pc)
+                        self._range_dictionary.add_context(pc)
                         # Add the sparse value class
                         from coverage_model.parameter_types import SparseConstantType
                         self._range_value[p] = get_value_class(
@@ -1202,11 +1205,14 @@ class ComplexCoverage(AbstractCoverage):
             self._reference_covs[cpth] = cov
 
             # Add parameters from the coverage if not already present
-            for p in cov.list_parameters():
+            covpd = cov.parameter_dictionary # Provides a copy
+            for p, pc in covpd.iteritems():
                 if p not in parameter_dictionary:
                     if p not in self._range_dictionary:
                         # Add the context from the reference coverage
-                        self._range_dictionary.add_context(self._reference_covs[cpth]._range_dictionary.get_context(p))
+                        pc = pc[1]  # pc is a tuple (ordinal, ParameterContext)
+                        self._assign_domain(pc)
+                        self._range_dictionary.add_context(pc)
                         # Add the sparse value class
                         from coverage_model.parameter_types import SparseConstantType
                         self._range_value[p] = get_value_class(

--- a/coverage_model/coverage.py
+++ b/coverage_model/coverage.py
@@ -1184,7 +1184,13 @@ class ComplexCoverage(AbstractCoverage):
         for cpth, cov in self._verify_rcovs(rcovs):
 
             # Get the time bounds for the coverage
-            tbnds = cov.get_data_bounds(cov.temporal_parameter_name)
+            if cov.num_timesteps == 0:
+                tbnds = (None, None)
+            else:
+                tbnds = cov.get_data_bounds(cov.temporal_parameter_name)
+                if tbnds[0] == tbnds[1]:
+                    tbnds = (tbnds[0], None)
+
             spn = Span(tbnds[0], tbnds[1], value=cpth)
 
             if spn in time_bounds:

--- a/coverage_model/coverage.py
+++ b/coverage_model/coverage.py
@@ -977,6 +977,12 @@ class ComplexCoverage(AbstractCoverage):
 
                 if parameter_dictionary is None:
                     parameter_dictionary = ParameterDictionary()
+                else:
+                    from coverage_model import ParameterFunctionType
+                    for pn, pc in parameter_dictionary.iteritems():
+                        if not isinstance(pc[1].param_type, ParameterFunctionType):
+                            log.warn('Parameters stored in a ComplexCoverage must be ParameterFunctionType parameters: discarding \'%s\'', pn)
+                            parameter_dictionary._map.pop(pn)
 
                 # Must be in 'a' for a new coverage
                 self.mode = 'a'

--- a/coverage_model/coverage.py
+++ b/coverage_model/coverage.py
@@ -959,10 +959,6 @@ class ComplexCoverage(AbstractCoverage):
 
                 self._reference_covs = {}
 
-                self._dobuild(self._persistence_layer.complex_type,
-                              reference_coverages=self._persistence_layer.rcov_locs,
-                              parameter_dictionary=self._persistence_layer.param_dict)
-
             if os.path.exists(pth):
                 _doload(self)
             else:
@@ -999,24 +995,27 @@ class ComplexCoverage(AbstractCoverage):
                                                                  complex_type=complex_type,
                                                                  coverage_type='complex')
 
-                self._dobuild(complex_type,
-                              reference_coverages=reference_coverage_locs,
-                              parameter_dictionary=parameter_dictionary)
+            self._dobuild()
 
         except:
             self._closed = True
             raise
 
-    def _dobuild(self, complex_type, **kwargs):
+    def _dobuild(self):
+        complex_type = self._persistence_layer.complex_type
+        reference_coverages = self._persistence_layer.rcov_locs
+        parameter_dictionary = self._persistence_layer.param_dict
+
+
         if complex_type == ComplexCoverageType.PARAMETRIC_STRICT:
             # PARAMETRIC_STRICT - combine parameters from multiple coverages - MUST HAVE IDENTICAL TIME VALUES
-            self._build_parametric(kwargs['reference_coverages'], kwargs['parameter_dictionary'])
+            self._build_parametric(reference_coverages, parameter_dictionary)
         elif complex_type == ComplexCoverageType.TEMPORAL_INTERLEAVED:
             # TEMPORAL_INTERLEAVED - combine parameters from multiple coverages - may have differing time values
-            self._build_temporal_interleaved(kwargs['reference_coverages'], kwargs['parameter_dictionary'])
+            self._build_temporal_interleaved(reference_coverages, parameter_dictionary)
         elif complex_type == ComplexCoverageType.TEMPORAL_AGGREGATION:
             # TEMPORAL_AGGREGATION - combine coverages temporally
-            self._build_temporal_aggregation(kwargs['reference_coverages'], kwargs['parameter_dictionary'])
+            self._build_temporal_aggregation(reference_coverages, parameter_dictionary)
         elif complex_type == ComplexCoverageType.SPATIAL_JOIN:
             # Complex spatial - combine coverages across a higher-order topology
             raise NotImplementedError('Not yet implemented')

--- a/coverage_model/parameter_types.py
+++ b/coverage_model/parameter_types.py
@@ -695,8 +695,8 @@ class ConstantType(AbstractComplexParameterType):
             if isinstance(value, ConstantValue):
                 if np.dtype(value.parameter_type.value_encoding).kind != 'S':
                     raise ValueError('\'value\' is a ConstantValue, with an invalid value_encoding; must be of kind=\'S\', is kind={0}'.format(np.dtype(value.parameter_type.value_encoding).kind))
-            elif isinstance(value, np.ndarray):
-                if value.dtype.kind != 'S':
+            elif not isinstance(value, basestring) and np.iterable(value):
+                if np.atleast_1d(value).dtype.kind != 'S':
                     raise ValueError('\'value\' is a numpy array, with an invalid dtype; must be kind=\'S\', is kind={0}'.format(value.dtype.kind))
             elif not isinstance(value, basestring):
                 raise ValueError('\'value\' must be a string with a max length of {0}; longer strings will be truncated'.format(dt.str[dt.str.index('S')+1:]))

--- a/coverage_model/parameter_values.py
+++ b/coverage_model/parameter_values.py
@@ -334,14 +334,18 @@ class SparseConstantValue(AbstractComplexParameterValue):
     def _apply_value(self, stor_sub, max_i):
         v_arr = np.empty(0, dtype=self.value_encoding)
         for s in stor_sub:
+            st = s.lower_bound or 0
+            en = s.upper_bound or max_i
+            # log.trace('st: %s, en: %s, offset: %s', st, en, s.offset)
+
+            if st == en == max_i:
+                break
+
             if isinstance(s.value, AbstractParameterValue):
-                e = s.value[:]
+                st += s.offset
+                en += s.offset
+                e = s.value[st:en]
             else:
-                st = s.lower_bound or 0
-                en = s.upper_bound or max_i
-
-                log.trace('st: %s, en: %s', st, en)
-
                 sz = en - st
                 e = np.empty(sz, dtype=self.value_encoding)
                 e.fill(s.value)
@@ -396,7 +400,7 @@ class SparseConstantValue(AbstractComplexParameterValue):
                     end_i = i + 1
                     break
 
-        log.trace('srt: %s, end: %s, fi: %s, li: %s', strt_i, end_i, fi, li)
+        # log.trace('srt: %s, end: %s, fi: %s, li: %s', strt_i, end_i, fi, li)
 
         stor_sub = spans[strt_i:end_i]
         # Build the array of stored values
@@ -441,6 +445,13 @@ class SparseConstantValue(AbstractComplexParameterValue):
             self._storage[0] = spans
             return
 
+        nspn_offset = 0
+        if isinstance(slice_[0], Span):
+            # TODO: This could be used to alter previous span objects, but for now, just use it to pass the offset
+            nspn_offset = slice_[0].offset
+        elif utils.slice_shape(slice_, self.shape) == self.shape:  # Full slice
+            nspn_offset = -self.shape[0]
+
         if not isinstance(value, AbstractParameterValue) and not isinstance(lspn.value, AbstractParameterValue):
             if value == lspn.value:
                 # The previous value equals the new value - do not add a new span!
@@ -449,11 +460,11 @@ class SparseConstantValue(AbstractComplexParameterValue):
         # The current index becomes the upper_bound of the previous span and the start of the next span
         curr_ind = self.shape[0]
 
-        # Create the new span
-        nspn = Span(curr_ind, None, value)
-
         # Reset the upper_bound of the previous span
-        spans[-1] = Span(lspn.lower_bound, curr_ind, lspn.value)
+        spans[-1] = Span(lspn.lower_bound, curr_ind, offset=lspn.offset, value=lspn.value)
+
+        # Create the new span
+        nspn = Span(curr_ind, None, nspn_offset, value=value)
 
         # Add the new span
         spans.append(nspn)

--- a/coverage_model/parameter_values.py
+++ b/coverage_model/parameter_values.py
@@ -331,9 +331,11 @@ class SparseConstantValue(AbstractComplexParameterValue):
 
         return rf.reshape(ss)
 
-    def _apply_value(self, stor_sub, max_i):
+    def _apply_value(self, stor_sub):
         v_arr = np.empty(0, dtype=self.value_encoding)
+        max_i = self.shape[0]
         for s in stor_sub:
+            # log.trace('s: %s, max_i: %s', s, max_i)
             st = s.lower_bound or 0
             en = s.upper_bound or max_i
             # log.trace('st: %s, en: %s, offset: %s', st, en, s.offset)
@@ -404,7 +406,7 @@ class SparseConstantValue(AbstractComplexParameterValue):
 
         stor_sub = spans[strt_i:end_i]
         # Build the array of stored values
-        v_arr = self._apply_value(stor_sub, li + 1)
+        v_arr = self._apply_value(stor_sub)
 
         if stor_sub[0].lower_bound is None:
             offset = 0

--- a/coverage_model/test/coverage_test_base.py
+++ b/coverage_model/test/coverage_test_base.py
@@ -321,7 +321,7 @@ class CoverageIntTestBase(object):
 
         # Refresh the read coverage
         read_cov.refresh()
-        
+
         self.assertTrue(np.array_equal(write_cov.get_time_values(), read_cov.get_time_values()))
 
     # ############################

--- a/coverage_model/test/test_basic_types.py
+++ b/coverage_model/test/test_basic_types.py
@@ -27,10 +27,12 @@ class TestBasicTypesUnit(CoverageModelUnitTestCase):
         self.assertIn(max_int, s)
         self.assertEqual(len(s), 0)
         self.assertEqual(s.value, 10)
+        self.assertEqual(s.indices(7), (0, 7, 1))
+        self.assertEqual(s.offset_indices(7), (0, 7, 1))
 
 
         # Unlimited lower bound
-        s = Span(None, 5, value='bob')
+        s = Span(None, 5, offset=3, value='bob')
         self.assertIn(min_int, s)
         self.assertIn(-18, s)
         self.assertIn(0, s)
@@ -39,9 +41,11 @@ class TestBasicTypesUnit(CoverageModelUnitTestCase):
         self.assertNotIn(19, s)
         self.assertEqual(len(s), 0)
         self.assertEqual(s.value, 'bob')
+        self.assertEqual(s.indices(10), (0, 5, 1))
+        self.assertEqual(s.offset_indices(10), (0, 8, 1))
 
         # Unlimited upper bound
-        s = Span(5, None, value=9.38)
+        s = Span(5, None, offset=-2, value=9.38)
         self.assertIn(max_int, s)
         self.assertIn(18, s)
         self.assertIn(6, s)
@@ -50,20 +54,24 @@ class TestBasicTypesUnit(CoverageModelUnitTestCase):
         self.assertNotIn(-12, s)
         self.assertEqual(len(s), 0)
         self.assertEqual(s.value, 9.38)
+        self.assertEqual(s.indices(12), (5, 12, 1))
+        self.assertEqual(s.offset_indices(12), (3, 12, 1))
 
         # Fully bounded
-        s = Span(10, 68, value=4)
+        s = Span(10, 68, offset=6, value=4)
         self.assertIn(34, s)
         self.assertNotIn(8, s)
         self.assertNotIn(90, s)
         self.assertEqual(len(s), 58)
         self.assertEqual(s.value, 4)
+        self.assertEqual(s.indices(30), (10, 30, 1))
+        self.assertEqual(s.offset_indices(30), (16, 30, 1))
 
     def test_ndspan(self):
         min_int = np.iinfo('int64').min
         max_int = np.iinfo('int64').max
         
-        s = NdSpan([Span(None,10), Span(3,30), Span(20,None)])
+        s = NdSpan([Span(None, 10), Span(3, 30), Span(20, None)])
         self.assertIn((8, 5, 23), s)
         self.assertIn((min_int, 29, max_int), s)
         self.assertNotIn((12, 5, 28), s)
@@ -72,7 +80,7 @@ class TestBasicTypesUnit(CoverageModelUnitTestCase):
         self.assertEqual(s.shape, (0, 27, 0))
         self.assertEqual(len(s), 0)
 
-        s = NdSpan([Span(0, 20), Span(4,8), Span(9, 18)])
+        s = NdSpan([Span(0, 20), Span(4, 8), Span(9, 18)])
         self.assertIn((7, 4, 15), s)
         self.assertIn((0, 7, 10), s)
         self.assertNotIn((20, 3, 18), s)

--- a/coverage_model/test/test_complex_coverage.py
+++ b/coverage_model/test/test_complex_coverage.py
@@ -279,7 +279,7 @@ class TestComplexCoverageInt(CoverageModelIntTestCase):
                               mock.call("Parameter '%s' from coverage '%s' already present, skipping...", 'time', covc_pth))
 
     def test_temporal_interleaved(self):
-        num_times = 2000
+        num_times = 200
         tpc = num_times / 2
 
         first_times = np.random.random_sample(tpc) * (20 - 0) + 0

--- a/coverage_model/test/test_complex_coverage.py
+++ b/coverage_model/test/test_complex_coverage.py
@@ -91,7 +91,7 @@ class TestComplexCoverageInt(CoverageModelIntTestCase):
         aplorng_ctxt = ParameterContext('apples_to_oranges', param_type=ParameterFunctionType(function=aplorng_func, value_encoding=np.dtype('float32')))
         pdict.add_context(aplorng_ctxt)
 
-        # Instantiate the SimplexCoverage providing the ParameterDictionary, spatial Domain and temporal Domain
+        # Instantiate the ComplexCoverage
         ccov = ComplexCoverage(self.working_dir, create_guid(), 'sample complex coverage',
                                reference_coverage_locs=[cova_pth, covb_pth, covc_pth],
                                parameter_dictionary=pdict,
@@ -187,7 +187,6 @@ class TestComplexCoverageInt(CoverageModelIntTestCase):
 
         comp_cov = ComplexCoverage(self.working_dir, create_guid(), 'sample temporal aggregation coverage',
                                    reference_coverage_locs=[cova_pth, covb_pth, covc_pth],
-                                   parameter_dictionary=ParameterDictionary(),
                                    complex_type=ComplexCoverageType.TEMPORAL_AGGREGATION)
 
         self.assertEqual(comp_cov.num_timesteps, 3*size)
@@ -266,7 +265,6 @@ class TestComplexCoverageInt(CoverageModelIntTestCase):
         with mock.patch('coverage_model.coverage.log') as log_mock:
             comp_cov = ComplexCoverage(self.working_dir, create_guid(), 'sample temporal aggregation coverage',
                                        reference_coverage_locs=[cova_pth, covb_pth, covc_pth],
-                                       parameter_dictionary=ParameterDictionary(),
                                        complex_type=ComplexCoverageType.TEMPORAL_AGGREGATION)
 
             self.assertEquals(log_mock.warn.call_args_list[0],
@@ -311,13 +309,9 @@ class TestComplexCoverageInt(CoverageModelIntTestCase):
                              data_dict={'time': second_times, 'second_param': second_data, 'full_param': second_full},
                              make_temporal=False)
 
-        # Instantiate a ParameterDictionary
-        pdict = ParameterDictionary()
-
-        # Instantiate the SimplexCoverage providing the ParameterDictionary, spatial Domain and temporal Domain
+        # Instantiate the ComplexCoverage
         ccov = ComplexCoverage(self.working_dir, create_guid(), 'sample complex coverage',
                                reference_coverage_locs=[cova_pth, covb_pth],
-                               parameter_dictionary=pdict,
                                complex_type=ComplexCoverageType.TEMPORAL_INTERLEAVED)
 
         self.assertEqual(ccov.list_parameters(), ['first_param', 'full_param', 'second_param', 'time'])
@@ -358,7 +352,6 @@ class TestComplexCoverageInt(CoverageModelIntTestCase):
         # Ensure the correct path is returned from ComplexCoverage.head_coverage_path in CC --> SC & SC scenario
         comp_cov = ComplexCoverage(self.working_dir, create_guid(), 'sample temporal aggregation coverage',
                                    reference_coverage_locs=[cova_pth, covb_pth],
-                                   parameter_dictionary=ParameterDictionary(),
                                    complex_type=ComplexCoverageType.TEMPORAL_AGGREGATION)
         self.assertEqual(comp_cov.head_coverage_path, covb_pth)
 
@@ -366,7 +359,6 @@ class TestComplexCoverageInt(CoverageModelIntTestCase):
         vcov = ViewCoverage(self.working_dir, create_guid(), 'test', covb_pth)
         comp_cov = ComplexCoverage(self.working_dir, create_guid(), 'sample temporal aggregation coverage',
                                    reference_coverage_locs=[cova_pth, vcov.persistence_dir],
-                                   parameter_dictionary=ParameterDictionary(),
                                    complex_type=ComplexCoverageType.TEMPORAL_AGGREGATION)
         self.assertEqual(comp_cov.head_coverage_path, covb_pth)
         self.assertEqual(comp_cov.head_coverage_path, vcov.head_coverage_path)

--- a/coverage_model/test/test_complex_coverage.py
+++ b/coverage_model/test/test_complex_coverage.py
@@ -174,6 +174,15 @@ class TestComplexCoverageInt(CoverageModelIntTestCase):
             self.assertEquals(log_mock.warn.call_args_list[0],
                               mock.call("Coverage '%s' does not have a temporal_parameter; ignoring", covb_pth))
 
+        with mock.patch('coverage_model.coverage.log') as log_mock:
+            pdict.add_context(ParameterContext('discard_me'))
+            ccov = ComplexCoverage(self.working_dir, create_guid(), 'sample complex coverage',
+                                   reference_coverage_locs=[cova_pth, cova_pth],
+                                   parameter_dictionary=pdict,
+                                   complex_type=ComplexCoverageType.PARAMETRIC_STRICT)
+            self.assertEqual(log_mock.warn.call_args_list[0],
+                             mock.call("Parameters stored in a ComplexCoverage must be ParameterFunctionType parameters: discarding '%s'", 'discard_me'))
+
     def test_temporal_aggregation(self):
         size = 100000
         first_times = np.arange(0, size, dtype='int64')


### PR DESCRIPTION
Adds support for ComplexCoverageType.TEMPORAL_INTERLEAVED - combines multiple coverages that exist on the same temporal domain.  Common parameters (BY NAME) are combined; disparate parameters are given fill_values for times they don't have data.

At this time, only 2 coverages can be interleaved - support for higher-order interleaving coming...

Also fixes some bugs/issues with previous ComplexCoverage stuff.
