### PR TITLE
Fixes bug with: temporal_interleave & empty coverage data query

### DIFF
--- a/coverage_model/coverage.py
+++ b/coverage_model/coverage.py
@@ -367,6 +367,10 @@ class AbstractCoverage(AbstractIdentifiable):
             log.debug('Spatial doa: %s', sdoa.slices)
             slice_.extend(sdoa.slices)
 
+        # If this coverage is empty - return an empty array
+        if np.atleast_1d(np.atleast_1d(total_shape) == 0).all():
+            return np.empty(0, dtype=self._range_value[param_name].value_encoding)
+
         slice_ = utils.fix_slice(slice_, total_shape)
         log.debug('Getting slice: %s', slice_)
 

--- a/coverage_model/coverage.py
+++ b/coverage_model/coverage.py
@@ -1026,8 +1026,6 @@ class ComplexCoverage(AbstractCoverage):
             self._build_parametric(reference_coverages, parameter_dictionary)
         elif complex_type == ComplexCoverageType.TEMPORAL_INTERLEAVED:
             # TEMPORAL_INTERLEAVED - combine parameters from multiple coverages - may have differing time values
-            if len(reference_coverages) > 2:
-                raise NotImplementedError('Cannot support interleaving of more than 2 coverages at this time.')
             self._build_temporal_interleaved(reference_coverages, parameter_dictionary)
         elif complex_type == ComplexCoverageType.TEMPORAL_AGGREGATION:
             # TEMPORAL_AGGREGATION - combine coverages temporally
@@ -1181,8 +1179,8 @@ class ComplexCoverage(AbstractCoverage):
             else:
                 low = min(curr)
                 high = max(curr) + 1
-                rcov_domain_spans.append(Span(low, high, offset=counter[key] - low, value=s))
-                counter[key] += len(curr)
+                rcov_domain_spans.append(Span(low, high, offset=counter[s] - low, value=s))
+                counter[s] += high-low
                 curr = []
                 s = key
                 curr.append(i)
@@ -1190,7 +1188,6 @@ class ComplexCoverage(AbstractCoverage):
         # Don't forget the last one!
         low = min(curr)
         high = max(curr) + 1
-        counter[key] -= len(curr)
         rcov_domain_spans.append(Span(low, high, offset=counter[key] - low, value=s))
 
         self.rcov_domain_spans = rcov_domain_spans

--- a/coverage_model/persistence.py
+++ b/coverage_model/persistence.py
@@ -633,6 +633,9 @@ class PersistedStorage(AbstractStorage):
         from coverage_model import bricking_utils, utils
 
         extents = tuple([s for s in self.total_domain.total_extents if s != 0])
+        if extents == ():  # Empty domain(s) - no data, return empty array
+            return np.empty(0, dtype=self.dtype)
+
         # bricks is a list of tuples [(b_ord, b_guid), ...]
         slice_ = utils.fix_slice(deepcopy(slice_), extents)
         log.trace('slice_=%s', slice_)

--- a/coverage_model/test/coverage_test_base.py
+++ b/coverage_model/test/coverage_test_base.py
@@ -551,7 +551,6 @@ class CoverageIntTestBase(object):
         with self.assertRaises(IndexError):
             scov.get_parameter_values('time', [[5,9000]])
 
-    @get_props()
     def test_get_by_slice(self):
         # Tests retrieving data across multiple bricks for a variety of slices
         results = []

--- a/coverage_model/test/test_complex_coverage.py
+++ b/coverage_model/test/test_complex_coverage.py
@@ -570,7 +570,7 @@ class TestComplexCoverageInt(CoverageModelIntTestCase, CoverageIntTestBase):
 
     def test_temporal_interleaved_all_param_types(self):
         size = 10
-        covs, cov_data = self._setup_allparams(size=size, sequential_covs=False)
+        covs, cov_data = self._setup_allparams(size=size, num_covs=5, sequential_covs=False)
 
         comp_cov = ComplexCoverage(self.working_dir, create_guid(), 'sample temporal aggregation coverage',
                                    reference_coverage_locs=covs,

--- a/coverage_model/test/test_simplex_coverage.py
+++ b/coverage_model/test/test_simplex_coverage.py
@@ -234,17 +234,91 @@ class TestEmptySampleCovInt(CoverageModelIntTestCase, CoverageIntTestBase):
     def _insert_set_get(self, scov=None, timesteps=None, data=None, _slice=None, param='all'):
         return True
 
-    @unittest.skip('Does not apply to empty coverage.')
-    def test_refresh(self):
-        pass
+    def test_get_by_slice(self):
+        cov = self.get_cov()[0]
 
-    @unittest.skip('Does not apply to empty coverage.')
+        expected = np.empty(0, dtype=cov.get_parameter_context('time').param_type.value_encoding)
+
+        slices = [slice(None), slice(0, None), slice(None, 10), slice(2, 8), slice(3, 19, 8)]
+
+        for s in slices:
+            ret = cov.get_parameter_values('time', s)
+            self.assertTrue(np.array_equal(ret, expected))
+
+    def test_get_by_int(self):
+        cov = self.get_cov()[0]
+
+        expected = np.empty(0, dtype=cov.get_parameter_context('time').param_type.value_encoding)
+
+        ints = [0, 2, 5, 109]
+
+        for i in ints:
+            ret = cov.get_parameter_values('time', i)
+            self.assertTrue(np.array_equal(ret, expected))
+
+    def test_get_by_list(self):
+        cov = self.get_cov()[0]
+
+        expected = np.empty(0, dtype=cov.get_parameter_context('time').param_type.value_encoding)
+
+        lists = [[[1,2,3]], [[3,5,19]]]
+
+        for l in lists:
+            ret = cov.get_parameter_values('time', l)
+            self.assertTrue(np.array_equal(ret, expected))
+
+    def test_slice_raises_index_error_out_out(self):
+        # Tests that an array defined totally outside the coverage data bounds raises an error when attempting retrieval
+        brick_size = 1000
+        time_steps = 5000
+        scov, cov_name = self.get_cov(brick_size=brick_size, nt=time_steps)
+        _slice = slice(5010, 5020, None)
+        self.assertTrue(np.array_equal(
+            scov.get_parameter_values('time', _slice),
+            np.empty(0, dtype=scov.get_parameter_context('time').param_type.value_encoding)))
+
+    def test_int_raises_index_error(self):
+        # Tests that an integer defined outside the coverage data bounds raises an error when attempting retrieval
+        brick_size = 1000
+        time_steps = 5000
+        scov, cov_name = self.get_cov(brick_size=brick_size, nt=time_steps)
+        self.assertTrue(np.array_equal(
+            scov.get_parameter_values('time', 9000),
+            np.empty(0, dtype=scov.get_parameter_context('time').param_type.value_encoding)))
+
+    def test_array_raises_index_error(self):
+        # Tests that an array defined outside the coverage data bounds raises an error when attempting retrieval
+        brick_size = 1000
+        time_steps = 5000
+        scov, cov_name = self.get_cov(brick_size=brick_size, nt=time_steps)
+        self.assertTrue(np.array_equal(
+            scov.get_parameter_values('time', [[5,9000]]),
+            np.empty(0, dtype=scov.get_parameter_context('time').param_type.value_encoding)))
+
+    # @unittest.skip('Does not apply to empty coverage.')
+    # def test_refresh(self):
+    #     pass
+
     def test_get_time_data_metrics(self):
-        pass
+        cov = self.get_cov(only_time=True)[0]
 
-    @unittest.skip('Does not apply to empty coverage.')
+        with self.assertRaises(ValueError):
+            cov.get_data_bounds('time')
+
+        with self.assertRaises(ValueError):
+            cov.get_data_bounds_by_axis(axis=AxisTypeEnum.TIME)
+
+        self.assertEqual(cov.get_data_extents('time'), (0,))
+        self.assertEqual(cov.get_data_extents_by_axis(AxisTypeEnum.TIME), (0,))
+
     def test_get_all_data_metrics(self):
-        pass
+        cov = self.get_cov()[0]
+
+        with self.assertRaises(ValueError):
+            cov.get_data_bounds()
+
+        self.assertEqual(cov.get_data_extents(),
+                         {'conductivity': (0,), 'lat': (0,), 'lon': (0,), 'temp': (0,), 'time': (0,)})
 
     @unittest.skip('Does not apply to empty coverage.')
     def test_get_data_after_load(self):
@@ -252,18 +326,6 @@ class TestEmptySampleCovInt(CoverageModelIntTestCase, CoverageIntTestBase):
 
     @unittest.skip('Does not apply to empty coverage.')
     def test_append_parameter(self):
-        pass
-
-    @unittest.skip('Does not apply to empty coverage.')
-    def test_get_by_slice(self):
-        pass
-
-    @unittest.skip('Does not apply to empty coverage.')
-    def test_get_by_int(self):
-        pass
-
-    @unittest.skip('Does not apply to empty coverage.')
-    def test_get_by_list(self):
         pass
 
     @unittest.skip('Does not apply to empty coverage.')


### PR DESCRIPTION
Fixes issue with temporal_interleave allowing any number of coverages to be interleaved - was previously restricted to 2 coverages

Addresses issue with querying against an empty coverage.  Now returns an empty array
