### PR TITLE
Adds 'inner_encoding' to ArrayType

### DIFF
--- a/coverage_model/parameter_types.py
+++ b/coverage_model/parameter_types.py
@@ -787,11 +787,14 @@ class ArrayType(AbstractComplexParameterType):
     """
     Homogeneous set of unnamed things (array)
     """
-    def __init__(self, **kwargs):
+    def __init__(self, inner_encoding=None, **kwargs):
         """
 
         @param **kwargs Additional keyword arguments are copied and the copy is passed up to AbstractComplexParameterType; see documentation for that class for details
         """
         kwc=kwargs.copy()
         AbstractComplexParameterType.__init__(self, value_class='ArrayValue', **kwc)
+
+        self.inner_encoding = inner_encoding
+
         self._gen_template_attrs()

--- a/coverage_model/parameter_values.py
+++ b/coverage_model/parameter_values.py
@@ -22,11 +22,17 @@ def get_value_class(param_type, domain_set, **kwargs):
 
 
 def _cleanse_value(val, slice_):
+    val = np.atleast_1d(val).squeeze()
+
     ret = np.atleast_1d(val)
 
     # If the array is size 1 AND a slice object was NOT part of the query
     if ret.size == 1 and not np.atleast_1d([isinstance(s, slice) for s in slice_]).all():
         val = ret[0]
+
+
+    if isinstance(val, np.ndarray) and val.ndim == 0:
+        val = val[()]
 
     return val
 

--- a/coverage_model/test/test_parameter_values.py
+++ b/coverage_model/test/test_parameter_values.py
@@ -61,7 +61,7 @@ class TestParameterValuesUnit(CoverageModelUnitTestCase):
         for x in xrange(num_rec):
             aval[x] = np.random.bytes(np.random.randint(1,20)) # One value (which is a byte string) for each member of the domain
 
-        self.assertIsInstance(aval[0][0], basestring)
+        self.assertIsInstance(aval[0], basestring)
         self.assertTrue(1 <= len(aval[0]) <= 20)
 
         vals = [[1, 2, 3]] * num_rec
@@ -70,13 +70,13 @@ class TestParameterValuesUnit(CoverageModelUnitTestCase):
 
         aval[:] = vals
         self.assertTrue(np.array_equal(aval[:], val_arr))
-        self.assertIsInstance(aval[0][0], list)
-        self.assertEqual(aval[0][0], [1, 2, 3])
+        self.assertIsInstance(aval[0], list)
+        self.assertEqual(aval[0], [1, 2, 3])
 
         aval[:] = val_arr
         self.assertTrue(np.array_equal(aval[:], val_arr))
-        self.assertIsInstance(aval[0][0], list)
-        self.assertEqual(aval[0][0], [1, 2, 3])
+        self.assertIsInstance(aval[0], list)
+        self.assertEqual(aval[0], [1, 2, 3])
 
 
     # RecordType
@@ -644,10 +644,10 @@ class TestParameterValuesInteropInt(CoverageModelIntTestCase):
         self._interop_assertions(cov, 'array_ie', arr_val_ie, vals_arr_ie)
 
         # String Assignment via list
-        self._interop_assertions(cov, 'array', arr_val, svals)
+        self._interop_assertions_str(cov, 'array', arr_val, svals)
 
         # String Assignment via array
-        self._interop_assertions(cov, 'array', arr_val, svals_arr)
+        self._interop_assertions_str(cov, 'array', arr_val, svals_arr)
 
     def test_category_value_interop(self):
         # Setup the type
@@ -673,16 +673,16 @@ class TestParameterValuesInteropInt(CoverageModelIntTestCase):
         # Perform the assertions
 
         # Assign with a list of keys
-        self._interop_assertions(cov, 'category', cat_val, key_vals)
+        self._interop_assertions_str(cov, 'category', cat_val, key_vals)
 
         # Assign with a list of categories
-        self._interop_assertions(cov, 'category', cat_val, cat_vals)
+        self._interop_assertions_str(cov, 'category', cat_val, cat_vals)
 
         # Assign with an array of keys
-        self._interop_assertions(cov, 'category', cat_val, key_vals_arr)
+        self._interop_assertions_str(cov, 'category', cat_val, key_vals_arr)
 
         # Assign with an array of categories
-        self._interop_assertions(cov, 'category', cat_val, cat_vals_arr)
+        self._interop_assertions_str(cov, 'category', cat_val, cat_vals_arr)
 
     def test_sparse_constant_value_interop(self):
         # Setup the type


### PR DESCRIPTION
Adds 'inner_encoding' attribute to ArrayType parameter type.  The attribute enables outbound (retrieval) conversion of the stored object-array into an ndarray who's datatype is indicated by inner_encoding.  Object and String data types are not converted.  If inner_encoding is None, the array is NOT converted,  this is the default.

Verified only for single-nested arrays (i.e. result in a 2d array).
