### PR TITLE
Fixes bug with default fill_value

### DIFF
--- a/coverage_model/parameter_types.py
+++ b/coverage_model/parameter_types.py
@@ -88,7 +88,7 @@ class AbstractParameterType(AbstractIdentifiable):
                     if dtk == 'i':
                         self._fill_value = np.iinfo(dt).max
                     elif dtk == 'f':
-                        self._fill_value = np.finfo(dt).max
+                        self._fill_value = np.asscalar(np.finfo(dt).max)
 
         else:
             self._fill_value = value


### PR DESCRIPTION
Addresses issue where default float fill values are set as numpy.number objects rather than builtin types - can cause issues downstream when serializing to JSON
