### PR TITLE
Adds support for ArrayType in SparseConstantType

### DIFF
--- a/coverage_model/parameter_types.py
+++ b/coverage_model/parameter_types.py
@@ -36,6 +36,55 @@ if platform.uname()[-2] != 'armv7l':
 # Abstract Parameter Type Objects
 #==================
 
+
+def verify_encoding(value_encoding):
+    if value_encoding is None:
+        value_encoding = np.dtype('float32').str
+    else:
+        try:
+            dt = np.dtype(value_encoding)
+            if dt.isbuiltin not in (0,1):
+                raise TypeError('\'value_encoding\' must be a valid numpy dtype: {0}'.format(value_encoding))
+            if dt in UNSUPPORTED_DTYPES:
+                raise TypeError('\'value_encoding\' {0} is not supported by H5py: UNSUPPORTED types ==> {1}'.format(value_encoding, UNSUPPORTED_DTYPES))
+
+            value_encoding = dt.str
+
+        except TypeError:
+            raise
+
+    return value_encoding
+
+
+def verify_fill_value(value_encoding, value, is_object_type):
+    if value_encoding is not None:
+        dt = np.dtype(value_encoding)
+        dtk = dt.kind
+        if dtk == 'O' or is_object_type: # object & CategoryRangeType must be None for now...
+            return None
+
+        elif dtk == 'u': # Unsigned integer's must be positive
+            if value is not None:
+                return abs(value)
+            else:
+                return np.iinfo(dt).max
+
+        elif dtk == 'S': # must be a string value
+            return str(value)
+
+        else:
+            if value is not None:
+                return value
+            else:
+                if dtk == 'i':
+                    return np.iinfo(dt).max
+                elif dtk == 'f':
+                    return np.asscalar(np.finfo(dt).max)
+
+    else:
+        return value
+
+
 class AbstractParameterType(AbstractIdentifiable):
     """
     Base class for parameter typing
@@ -66,32 +115,7 @@ class AbstractParameterType(AbstractIdentifiable):
 
     @fill_value.setter
     def fill_value(self, value):
-        if hasattr(self, 'value_encoding'):
-            dt = np.dtype(self.value_encoding)
-            dtk = dt.kind
-            if dtk == 'O' or isinstance(self, ConstantRangeType): # object & CategoryRangeType must be None for now...
-                self._fill_value = None
-
-            elif dtk == 'u': # Unsigned integer's must be positive
-                if value is not None:
-                    self._fill_value = abs(value)
-                else:
-                    self._fill_value = np.iinfo(dt).max
-
-            elif dtk == 'S': # must be a string value
-                self._fill_value = str(value)
-
-            else:
-                if value is not None:
-                    self._fill_value = value
-                else:
-                    if dtk == 'i':
-                        self._fill_value = np.iinfo(dt).max
-                    elif dtk == 'f':
-                        self._fill_value = np.asscalar(np.finfo(dt).max)
-
-        else:
-            self._fill_value = value
+        self._fill_value = verify_fill_value(self.value_encoding, value, isinstance(self, ConstantRangeType))
 
     @property
     def value_encoding(self):
@@ -469,6 +493,8 @@ class TextType(AbstractSimplexParameterType):
         kwc=kwargs.copy()
         AbstractSimplexParameterType.__init__(self, **kwc)
 
+        self._value_encoding = str
+
         self._template_attrs['fill_value'] = ''
 
         self._gen_template_attrs()
@@ -787,7 +813,7 @@ class ArrayType(AbstractComplexParameterType):
     """
     Homogeneous set of unnamed things (array)
     """
-    def __init__(self, inner_encoding=None, **kwargs):
+    def __init__(self, inner_encoding=None, inner_fill_value=None, **kwargs):
         """
 
         @param **kwargs Additional keyword arguments are copied and the copy is passed up to AbstractComplexParameterType; see documentation for that class for details
@@ -795,6 +821,11 @@ class ArrayType(AbstractComplexParameterType):
         kwc=kwargs.copy()
         AbstractComplexParameterType.__init__(self, value_class='ArrayValue', **kwc)
 
-        self.inner_encoding = inner_encoding
+        if inner_encoding is None or np.dtype(inner_encoding).kind in ['S', 'O']:
+            self.inner_encoding = None
+        else:
+            self.inner_encoding = verify_encoding(inner_encoding)
+
+        self.inner_fill_value = verify_fill_value(self.inner_encoding, inner_fill_value, False)
 
         self._gen_template_attrs()

--- a/coverage_model/parameter_types.py
+++ b/coverage_model/parameter_types.py
@@ -614,8 +614,8 @@ class SparseConstantType(AbstractComplexParameterType):
         if 'value_encoding' in kwc:
             ve = kwc.pop('value_encoding')
         AbstractComplexParameterType.__init__(self, value_class='SparseConstantValue', **kwc)
-        if base_type is not None and not isinstance(base_type, ConstantType):
-            raise TypeError('\'base_type\' must be an instance of ConstantType')
+        if base_type is not None and not isinstance(base_type, (ConstantType, ArrayType)):
+            raise TypeError('\'base_type\' must be an instance of ConstantType or ArrayType')
 
         self.base_type = base_type or ConstantType(value_encoding=ve)
 

--- a/coverage_model/test/test_parameter_values.py
+++ b/coverage_model/test/test_parameter_values.py
@@ -610,7 +610,7 @@ class TestParameterValuesInteropInt(CoverageModelIntTestCase):
     def test_array_value_interop(self):
         # Setup the type
         arr_type = ArrayType()
-        arr_type_ie = ArrayType(inner_encoding='float32')
+        arr_type_ie = ArrayType(inner_encoding=np.dtype('int32'))
 
         # Setup the values
         ntimes = 20
@@ -688,7 +688,8 @@ class TestParameterValuesInteropInt(CoverageModelIntTestCase):
     def test_sparse_constant_value_interop(self):
          # Setup the type
         scv_type = SparseConstantType(fill_value=-998, value_encoding='int32')
-        scv_arr_type = SparseConstantType(base_type=ArrayType(inner_encoding='float32'))
+        ifv = 827.38
+        scv_arr_type = SparseConstantType(base_type=ArrayType(inner_encoding='float32', inner_fill_value=ifv))
 
         # Setup the values
         ntimes = 10
@@ -759,7 +760,7 @@ class TestParameterValuesInteropInt(CoverageModelIntTestCase):
         aval = [[39, 2, 394, 55]]
         aval_arr = np.empty(1, dtype=object)
         aval_arr[0] = aval
-        awant = np.hstack((awant, np.array([[-999.]] * ntimes)))
+        awant = np.hstack((awant, np.array([[827.38]] * ntimes)))
         awant = np.vstack((awant, np.array(aval * ntimes, dtype='float32')))
 
         # Assign with val
@@ -780,8 +781,8 @@ class TestParameterValuesInteropInt(CoverageModelIntTestCase):
         self.assertTrue(np.array_equal(cov.get_parameter_values('scv'), want))
 
         self._interop_assertions(cov, 'scv_arr', scv_arr_val)
-        self.assertTrue(np.array_equal(scv_arr_val[:], awant))
-        self.assertTrue(np.array_equal(cov.get_parameter_values('scv_arr'), awant))
+        self.assertTrue(np.allclose(scv_arr_val[:], awant))
+        self.assertTrue(np.allclose(cov.get_parameter_values('scv_arr'), awant))
 
         # Reassign last segment
         val = 44
@@ -804,5 +805,5 @@ class TestParameterValuesInteropInt(CoverageModelIntTestCase):
         self.assertTrue(np.array_equal(cov.get_parameter_values('scv'), want))
 
         self._interop_assertions(cov, 'scv_arr', scv_arr_val)
-        self.assertTrue(np.array_equal(scv_arr_val[:], awant))
-        self.assertTrue(np.array_equal(cov.get_parameter_values('scv_arr'), awant))
+        self.assertTrue(np.allclose(scv_arr_val[:], awant))
+        self.assertTrue(np.allclose(cov.get_parameter_values('scv_arr'), awant))

--- a/coverage_model/test/test_parameter_values.py
+++ b/coverage_model/test/test_parameter_values.py
@@ -329,7 +329,8 @@ class TestParameterValuesInteropInt(CoverageModelIntTestCase):
         self.assertTrue(np.array_equal(cov.get_parameter_values(pname), val_cls[:]))
         self.assertTrue(np.array_equal(cov.get_parameter_values(pname, slice(-1, None)), val_cls[-1:]))
         self.assertTrue(np.array_equal(cov.get_parameter_values(pname, slice(None, None, 3)), val_cls[::3]))
-        if isinstance(val_cls.parameter_type, ArrayType):
+        if isinstance(val_cls.parameter_type, ArrayType) or \
+                (hasattr(val_cls.parameter_type, 'base_type') and isinstance(val_cls.parameter_type.base_type, ArrayType)):
             self.assertTrue(np.array_equal(cov.get_parameter_values(pname, 0), val_cls[0]))
             self.assertTrue(np.array_equal(cov.get_parameter_values(pname, -1), val_cls[-1]))
         else:
@@ -685,31 +686,45 @@ class TestParameterValuesInteropInt(CoverageModelIntTestCase):
         self._interop_assertions_str(cov, 'category', cat_val, cat_vals_arr)
 
     def test_sparse_constant_value_interop(self):
-        # Setup the type
+         # Setup the type
         scv_type = SparseConstantType(fill_value=-998, value_encoding='int32')
+        scv_arr_type = SparseConstantType(base_type=ArrayType(inner_encoding='float32'))
 
         # Setup the values
         ntimes = 10
         val = 20
         val_list = [20, 40]
         val_arr = np.array(val_list, dtype='int32')
+        want = np.array([val] * ntimes, dtype='int32')
+
+        aval = [[20, 39, 58]]
+        aval_arr = np.empty(1, dtype=object)
+        aval_arr[0] = aval[0]
+        awant = np.array(aval * ntimes, dtype='float32')
 
         # Setup the in-memory value
         dom = SimpleDomainSet((ntimes,))
         scv_val = get_value_class(scv_type, dom)
+        scv_arr_val = get_value_class(scv_arr_type, dom)
 
         # Setup the coverage
-        cov = self._setup_cov(ntimes, ['scv'], [scv_type])
+        cov = self._setup_cov(ntimes, ['scv', 'scv_arr'], [scv_type, scv_arr_type])
 
         # Perform the assertions
 
-        want = np.array([val] * ntimes, dtype='int32')
         # Assign with val
         scv_val[:] = val
         cov.set_parameter_values('scv', val)
         self._interop_assertions(cov, 'scv', scv_val)
         self.assertTrue(np.array_equal(scv_val[:], want))
         self.assertTrue(np.array_equal(cov.get_parameter_values('scv'), want))
+
+        # Assign with aval
+        scv_arr_val[:] = aval
+        cov.set_parameter_values('scv_arr', aval)
+        self._interop_assertions(cov, 'scv_arr', scv_arr_val)
+        self.assertTrue(np.array_equal(scv_arr_val[:], awant))
+        self.assertTrue(np.array_equal(cov.get_parameter_values('scv_arr'), awant))
 
         # Backfill assignment
 
@@ -727,6 +742,12 @@ class TestParameterValuesInteropInt(CoverageModelIntTestCase):
         self.assertTrue(np.array_equal(scv_val[:], want))
         self.assertTrue(np.array_equal(cov.get_parameter_values('scv'), want))
 
+        scv_arr_val[-1] = aval_arr
+        cov.set_parameter_values('scv_arr', aval_arr, -1)
+        self._interop_assertions(cov, 'scv_arr', scv_arr_val)
+        self.assertTrue(np.array_equal(scv_arr_val[:], awant))
+        self.assertTrue(np.array_equal(cov.get_parameter_values('scv_arr'), awant))
+
         # Add a new value and expand the domain
 
         # Change the values
@@ -735,26 +756,53 @@ class TestParameterValuesInteropInt(CoverageModelIntTestCase):
         val_arr = np.array(val_list, dtype='int32')
         want = np.append(want, np.array([val] * ntimes, dtype='int32'))
 
+        aval = [[39, 2, 394, 55]]
+        aval_arr = np.empty(1, dtype=object)
+        aval_arr[0] = aval
+        awant = np.hstack((awant, np.array([[-999.]] * ntimes)))
+        awant = np.vstack((awant, np.array(aval * ntimes, dtype='float32')))
+
         # Assign with val
         scv_val[:] = val
         cov.set_parameter_values('scv', val)
+
+        # Assign with aval
+        scv_arr_val[:] = aval
+        cov.set_parameter_values('scv_arr', aval)
+
         # Expand the domain
         dom.shape = (dom.shape[0] + ntimes,)
         cov.insert_timesteps(ntimes)
+
+        # Validate values
         self._interop_assertions(cov, 'scv', scv_val)
         self.assertTrue(np.array_equal(scv_val[:], want))
         self.assertTrue(np.array_equal(cov.get_parameter_values('scv'), want))
 
-        # Assign with list
-        scv_val[:] = val_list
-        cov.set_parameter_values('scv', val_list)
+        self._interop_assertions(cov, 'scv_arr', scv_arr_val)
+        self.assertTrue(np.array_equal(scv_arr_val[:], awant))
+        self.assertTrue(np.array_equal(cov.get_parameter_values('scv_arr'), awant))
+
+        # Reassign last segment
+        val = 44
+        want[ntimes:] = val
+
+        aval = [[39, 2, 3, 44]]
+        awant[ntimes:] = aval
+
+        # Assign with val
+        scv_val[-1] = val
+        cov.set_parameter_values('scv', val, -1)
+
+        # Assign with aval
+        scv_arr_val[-1] = aval
+        cov.set_parameter_values('scv_arr', aval, -1)
+
+        # Validate values
         self._interop_assertions(cov, 'scv', scv_val)
         self.assertTrue(np.array_equal(scv_val[:], want))
         self.assertTrue(np.array_equal(cov.get_parameter_values('scv'), want))
 
-        # Asign with array
-        scv_val[:] = val_arr
-        cov.set_parameter_values('scv', val_arr)
-        self._interop_assertions(cov, 'scv', scv_val)
-        self.assertTrue(np.array_equal(scv_val[:], want))
-        self.assertTrue(np.array_equal(cov.get_parameter_values('scv'), want))
+        self._interop_assertions(cov, 'scv_arr', scv_arr_val)
+        self.assertTrue(np.array_equal(scv_arr_val[:], awant))
+        self.assertTrue(np.array_equal(cov.get_parameter_values('scv_arr'), awant))


### PR DESCRIPTION
Adds the ability to have SparseConstantType utilize ArrayType as it's base_type

Moves application of inner_encoding of ArrayType to classmethod ArrayType._apply_inner_encoding

Updates test_sparse_constant_value_interop
