### PR TITLE
Fixes memory leak

### DIFF
--- a/coverage_model/base_test_cases.py
+++ b/coverage_model/base_test_cases.py
@@ -22,6 +22,17 @@ class CoverageModelUnitTestCase(TestCase):
     def shortDescription(self):
         return None
 
+    # override __str__ and __repr__ behavior to show a copy-pastable nosetest name for ion tests
+    #  ion.module:TestClassName.test_function_name
+    def __repr__(self):
+        name = self.id()
+        name = name.split('.')
+        if name[0] not in ["coverage_model"]:
+            return "%s (%s)" % (name[-1], '.'.join(name[:-1]))
+        else:
+            return "%s ( %s )" % (name[-1], '.'.join(name[:-2]) + ":" + '.'.join(name[-2:]))
+    __str__ = __repr__
+
 
 class CoverageModelIntTestCase(TestCase):
 
@@ -45,3 +56,14 @@ class CoverageModelIntTestCase(TestCase):
         # Removes temporary files
         # Comment this out if you need to inspect the HDF5 files.
         shutil.rmtree(cls.working_dir)
+
+    # override __str__ and __repr__ behavior to show a copy-pastable nosetest name for ion tests
+    #  ion.module:TestClassName.test_function_name
+    def __repr__(self):
+        name = self.id()
+        name = name.split('.')
+        if name[0] not in ["coverage_model"]:
+            return "%s (%s)" % (name[-1], '.'.join(name[:-1]))
+        else:
+            return "%s ( %s )" % (name[-1], '.'.join(name[:-2]) + ":" + '.'.join(name[-2:]))
+    __str__ = __repr__

--- a/coverage_model/coverage.py
+++ b/coverage_model/coverage.py
@@ -380,9 +380,7 @@ class AbstractCoverage(AbstractIdentifiable):
             key = (param_name, utils.hash_any(slk))
             try:
                 return_value = self._value_cache.pop(key)
-            #                print 'Vals from cache for \'%s\'' % param_name
             except KeyError:
-            #                print 'New vals for \'%s\'' % param_name
                 return_value = self._range_value[param_name][slice_]
                 if len(self._value_cache) >= self.VALUE_CACHE_LIMIT:
                     k, v = self._value_cache.popitem(0)
@@ -782,9 +780,6 @@ class AbstractCoverage(AbstractIdentifiable):
         lst.append('Data Parameters: {0}'.format(self.list_parameters(coords_only=False, data_only=True)))
 
         return '\n'.join(lst)
-
-    def __del__(self):
-        self.close()
 
 
 class ViewCoverage(AbstractCoverage):
@@ -1437,6 +1432,9 @@ class SimplexCoverage(AbstractCoverage):
                     self._bricking_scheme = bricking_scheme
 
                 self.value_caching = value_caching
+
+                # LOCK inline_data_writes to True
+                inline_data_writes = True
 
                 self._in_memory_storage = in_memory_storage
                 if self._in_memory_storage:

--- a/coverage_model/test/test_complex_coverage.py
+++ b/coverage_model/test/test_complex_coverage.py
@@ -284,7 +284,7 @@ class TestComplexCoverageInt(CoverageModelIntTestCase, CoverageIntTestBase):
 
             self.assertEquals(log_mock.warn.call_args_list[0],
                               mock.call('Coverage timestamps do not match; cannot include: %s', covb_pth))
-            self.assertEquals(log_mock.info.call_args_list[1],
+            self.assertEquals(log_mock.info.call_args_list[0],
                               mock.call("Parameter '%s' from coverage '%s' already present, skipping...", 'time', covc_pth))
 
         with mock.patch('coverage_model.coverage.log') as log_mock:
@@ -419,10 +419,10 @@ class TestComplexCoverageInt(CoverageModelIntTestCase, CoverageIntTestBase):
             self.assertEquals(log_mock.warn.call_args_list[3],
                               mock.call("Coverage with time bounds '%s' already present; ignoring", (first_times.min(), first_times.max(), 0)))
 
-            self.assertEquals(log_mock.info.call_args_list[1],
+            self.assertEquals(log_mock.info.call_args_list[0],
                               mock.call("Parameter '%s' from coverage '%s' already present, skipping...", 'data_all', covc_pth))
 
-            self.assertEquals(log_mock.info.call_args_list[2],
+            self.assertEquals(log_mock.info.call_args_list[1],
                               mock.call("Parameter '%s' from coverage '%s' already present, skipping...", 'time', covc_pth))
 
     def _setup_allparams(self, size=10, num_covs=2, sequential_covs=True):

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(  name = 'coverage-model',
         'netCDF4>=0.9.8',
         'numexpr==2.1',
         'h5py==2.1.1a2', 
-        'rtree==0.7.0',
+        # 'rtree==0.7.0', # Removed due to memory leak - see commit: 2e4af870905c64d5f3435744177084c905833db3
         'pidantic',
         'nose==1.1.2',  # must specify to avoid GSW from getting the latest version - which conflicts with pyon's
         'gsw==3.0.1a1',


### PR DESCRIPTION
Deals with the memory leak associated with overriding of **del** within the AbstractCoverage class.

Also handles ramifications of removing this override, which includes:
- Removal of RTree library due to segmentation faults
- Locking to inline_data_writes == True (no big deal as this was the only way coverage was being used anyhow)
- Updates to tests (minor)
