### PR TITLE
Adds context management ('with ...') to coverage

### DIFF
--- a/coverage_model/coverage.py
+++ b/coverage_model/coverage.py
@@ -79,6 +79,13 @@ class AbstractCoverage(AbstractIdentifiable):
         else:
             self.mode = 'r'
 
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        # Ensure the coverage is closed
+        self.close()
+
     @classmethod
     def pickle_save(cls, cov_obj, file_path, use_ascii=False):
         if not isinstance(cov_obj, AbstractCoverage):

--- a/coverage_model/test/coverage_test_base.py
+++ b/coverage_model/test/coverage_test_base.py
@@ -204,6 +204,22 @@ class CoverageIntTestBase(object):
             pc = cov.get_parameter_context(param)
             self.assertEqual(len(pc.dom.identifier), 36)
 
+    @get_props()
+    def test_context_management(self):
+        props = self.test_context_management.props
+        nt = props['time_steps']
+
+        with self.get_cov(nt=nt)[0] as cov:
+            self.assertEqual(cov.num_timesteps, nt)
+            for p in cov.list_parameters():
+                self.assertEqual(len(cov.get_parameter_values(p)), nt)
+            pdir = cov.persistence_dir
+
+        with AbstractCoverage.load(pdir) as cov:
+            self.assertEqual(cov.num_timesteps, nt)
+            for p in cov.list_parameters():
+                self.assertEqual(len(cov.get_parameter_values(p)), nt)
+
     def test_create_guid_valid(self):
         # Tests that the create_guid() function outputs a properly formed GUID
         self.assertTrue(len(create_guid()) == 36)


### PR DESCRIPTION
Adds the ability to create/load a coverage using the context management syntax --> with … as x:  This methodology ensures the coverage is closed at the end of the with block.

Adds test_context_management
