### PR TITLE
Enforces value_encoding for param funcs

### DIFF
--- a/coverage_model/parameter_values.py
+++ b/coverage_model/parameter_values.py
@@ -282,6 +282,12 @@ class ParameterFunctionValue(AbstractSimplexParameterValue):
 
             try:
                 r = self.content.evaluate(self._pval_callback, slice_, self.parameter_type.fill_value)
+                ve = self.parameter_type.value_encoding
+                if hasattr(self.parameter_type, 'inner_encoding'):
+                    ve = self.parameter_type.inner_encoding
+
+                if ve is not None:
+                    r = np.asanyarray(r, dtype=ve)
             except Exception as ex:
                 import sys
                 raise ParameterFunctionException(ex.message, type(ex)), None, sys.exc_traceback

--- a/coverage_model/test/test_parameter_values.py
+++ b/coverage_model/test/test_parameter_values.py
@@ -588,6 +588,12 @@ class TestParameterValuesInteropInt(CoverageModelIntTestCase):
 
         # Perform the assertions
 
+        # Make sure the value_encoding is enforced
+        self.assertEqual(numexpr_val[:].dtype, np.dtype('int32'))
+        self.assertEqual(pyfunc_val[:].dtype, np.dtype('float32'))
+        self.assertEqual(cov.get_parameter_values('numexpr').dtype, np.dtype('int32'))
+        self.assertEqual(cov.get_parameter_values('pyfunc').dtype, np.dtype('float32'))
+
         # NumexprFunction
         self._interop_assertions(cov, 'numexpr', numexpr_val)
 


### PR DESCRIPTION
Ensures the provided value_encoding is enforced for ParameterFunctionType parameters
