### PR TITLE
Downgrades a some logging; skips unnecessary test

### DIFF
--- a/coverage_model/coverage.py
+++ b/coverage_model/coverage.py
@@ -226,7 +226,7 @@ class AbstractCoverage(AbstractIdentifiable):
         # Get the parameter variability; assign to VariabilityEnum.NONE if None
         pv = pcontext.variability or VariabilityEnum.NONE
         if no_sdom and pv in (VariabilityEnum.SPATIAL, VariabilityEnum.BOTH):
-            log.warn('ParameterContext \'{0}\' indicates Spatial variability, but coverage has no Spatial Domain'.format(pcontext.name))
+            log.info('ParameterContext \'{0}\' indicates Spatial variability, but coverage has no Spatial Domain'.format(pcontext.name))
 
         if pv == VariabilityEnum.TEMPORAL: # Only varies in the Temporal Domain
             pcontext.dom = DomainSet(self.temporal_domain, None)

--- a/coverage_model/persistence.py
+++ b/coverage_model/persistence.py
@@ -599,7 +599,7 @@ class PersistedStorage(AbstractStorage):
             log.trace('brick_slice=%s\tbrick_mm=%s', brick_slice, brick_mm)
 
             if None in brick_slice:
-                log.info('Brick does not contain any of the requested indices: Move to next brick')
+                log.debug('Brick does not contain any of the requested indices: Move to next brick')
                 continue
 
             ret_slice = bricking_utils.get_value_slice_nd(slice_, ret_shp, bbnds, brick_slice, brick_mm)

--- a/coverage_model/test/coverage_test_base.py
+++ b/coverage_model/test/coverage_test_base.py
@@ -657,6 +657,7 @@ class CoverageIntTestBase(object):
 
     # ############################
     # INLINE & OUT OF BAND R/W
+    @unittest.skip('Out-of-band writes are not currently allowed')
     def test_run_test_dispatcher(self):
         from coverage_model.brick_dispatch import run_test_dispatcher
         disp=run_test_dispatcher(work_count=20, num_workers=1)

--- a/coverage_model/test/test_complex_coverage.py
+++ b/coverage_model/test/test_complex_coverage.py
@@ -418,13 +418,13 @@ class TestComplexCoverageInt(CoverageModelIntTestCase, CoverageIntTestBase):
                                        reference_coverage_locs=[cova_pth, covb_pth, covc_pth],
                                        complex_type=ComplexCoverageType.TEMPORAL_AGGREGATION)
 
-            self.assertEquals(log_mock.warn.call_args_list[3],
+            self.assertEquals(log_mock.warn.call_args_list[0],
                               mock.call("Coverage with time bounds '%s' already present; ignoring", (first_times.min(), first_times.max(), 0)))
 
-            self.assertEquals(log_mock.info.call_args_list[0],
+            self.assertEquals(log_mock.info.call_args_list[4],
                               mock.call("Parameter '%s' from coverage '%s' already present, skipping...", 'data_all', covc_pth))
 
-            self.assertEquals(log_mock.info.call_args_list[1],
+            self.assertEquals(log_mock.info.call_args_list[5],
                               mock.call("Parameter '%s' from coverage '%s' already present, skipping...", 'time', covc_pth))
 
     def _setup_allparams(self, size=10, num_covs=2, sequential_covs=True):


### PR DESCRIPTION
Downgrades a couple of log statements that can happen frequently and adjusts tests accordingly

Skips test_run_test_dispatcher because out-of-band writes are not allowed at this time and the test can result in failures due to HDF files that aren't closed properly or in a timely manner
