### PR TITLE
Repair Temporal Geometry

### DIFF
--- a/coverage_model/basic_types.py
+++ b/coverage_model/basic_types.py
@@ -407,6 +407,12 @@ class Span(AbstractBase):
 
     def __contains__(self, index):
 
+        if isinstance(index, Span):
+            return index.lower_bound in self and index.upper_bound in self
+
+        if index is None:
+            return True
+
         if self.lower_bound is None and self.upper_bound is None:
             return True
         elif self.lower_bound is None and index < self.upper_bound:

--- a/coverage_model/parameter_values.py
+++ b/coverage_model/parameter_values.py
@@ -90,6 +90,11 @@ class AbstractParameterValue(AbstractBase):
     def fill_value(self):
         return self.parameter_type.fill_value
 
+    def get_fill_array(self, size=1):
+        ve = self.value_encoding if self.fill_value is not None else np.dtype(object)
+
+        return np.array([self.fill_value]*size, dtype=ve)
+
     def expand_content(self, domain, origin, expansion):
         if domain == VariabilityEnum.TEMPORAL: # Temporal
             self._storage.expand(self.shape[1:], origin, expansion)

--- a/coverage_model/test/examples.py
+++ b/coverage_model/test/examples.py
@@ -571,6 +571,10 @@ def ptypescov(save_coverage=False, in_memory=False, inline_data_writes=True, mak
     fstr_ctxt.long_name = 'example of a fixed-length string parameter'
     pdict.add_context(fstr_ctxt)
 
+    sparse_ctxt = ParameterContext('sparse', param_type=SparseConstantType(base_type=ArrayType(inner_encoding='float32', inner_fill_value=-99)))
+    sparse_ctxt.long_naem = 'example of an opaque sparse constant parameter'
+    pdict.add_context(sparse_ctxt)
+
     # Instantiate the SimplexCoverage providing the ParameterDictionary, spatial Domain and temporal Domain
     scov = SimplexCoverage('test_data', create_guid(), 'sample coverage_model', parameter_dictionary=pdict, temporal_domain=tdom, spatial_domain=sdom, inline_data_writes=inline_data_writes, in_memory_storage=in_memory)
 
@@ -579,7 +583,12 @@ def ptypescov(save_coverage=False, in_memory=False, inline_data_writes=True, mak
         return scov
 
     nt = 20
-    scov.insert_timesteps(nt)
+
+    scov.set_parameter_values('sparse', [[[2, 4, 6], [8, 10, 12]]])
+    scov.insert_timesteps(nt/2)
+
+    scov.set_parameter_values('sparse', [[[4, 8], [16, 20]]])
+    scov.insert_timesteps(nt/2)
 
     # Add data for each parameter
     scov.set_parameter_values('quantity_time', value=np.arange(nt))

--- a/coverage_model/test/test_simplex_coverage.py
+++ b/coverage_model/test/test_simplex_coverage.py
@@ -376,7 +376,8 @@ class TestPtypesCovInt(CoverageModelIntTestCase, CoverageIntTestBase):
                             'quantity',
                             'array',
                             'record',
-                            'fixed_str']
+                            'fixed_str',
+                            'sparse']
 
         if only_time:
             pname_filter = ['time']
@@ -395,11 +396,19 @@ class TestPtypesCovInt(CoverageModelIntTestCase, CoverageIntTestBase):
         if (nt is None) or (nt == 0) or (make_empty is True):
             return scov, 'TestPtypesCovInt'
         else:
-            scov.insert_timesteps(nt)
-
             # Add data for each parameter
-            scov.set_parameter_values('time', value=np.arange(nt))
-            if not only_time:
+            print nt
+            if only_time:
+                scov.insert_timesteps(nt)
+                scov.set_parameter_values('time', value=np.arange(nt))
+            else:
+                scov.set_parameter_values('sparse', [[[2, 4, 6], [8, 10, 12]]])
+                scov.insert_timesteps(nt/2)
+
+                scov.set_parameter_values('sparse', [[[4, 8], [16, 20]]])
+                scov.insert_timesteps(nt/2)
+
+                scov.set_parameter_values('time', value=np.arange(nt))
                 scov.set_parameter_values('boolean', value=[True, True, True], tdoa=[[2,4,14]])
                 scov.set_parameter_values('const_float', value=-71.11) # Set a constant with correct data type
                 scov.set_parameter_values('const_int', value=45.32) # Set a constant with incorrect data type (fixed under the hood)

--- a/coverage_model/test/test_view_coverage.py
+++ b/coverage_model/test/test_view_coverage.py
@@ -18,7 +18,7 @@ from test_simplex_coverage import TestSampleCovInt as sc
 from coverage_test_base import *
 
 
-@attr('INT', group='view_cov')
+@attr('INT', group='cov')
 class TestSampleCovViewInt(CoverageModelIntTestCase, CoverageIntTestBase):
 
     # Make a deep copy of the base TESTING_PROPERTIES dict and then modify for this class

--- a/coverage_model/utils.py
+++ b/coverage_model/utils.py
@@ -87,14 +87,27 @@ def _raise_index_error_int(slice_, size, dim):
 
 
 def _raise_index_error_list(slice_, size, dim):
-    last = -1
-    for i in xrange(len(slice_)):
-        c=slice_[i]
-        if last >= c:
-            raise IndexError('On dimension {0}; indices must be in increasing order and cannot be duplicated: list => {1}'.format(dim, slice_))
-        last = c
-        if slice_[i] >= size:
-            raise IndexError('On dimension {0}; index {1} of list cannot be >= the size: list => {2}, size => {3}'.format(dim, i, slice_, size))
+    # This restriction is NOT in alignment with how numpy works - but HDF doesn't support non-increasing or duplication in list slicing
+    if not (np.array_equal(np.sort(slice_), slice_) and np.array_equal(np.unique(slice_), slice_)):
+        raise IndexError('On dimension {0}; indices must be in increasing order and cannot be duplicated: list => {1}'.format(dim, slice_))
+
+    if (np.array(slice_) >= size).any():
+        raise IndexError('On dimension {0}; members of the list cannot be >= the size: list => {1}, size => {2}'.format(dim, slice_, size))
+
+    # last = -1
+    # for i in xrange(len(slice_)):
+    #     ## TODO: Re-evaluate why we wanted this - numpy allows it, why shouldn't we?  more follows...
+    #     ## The main reason is because HDF doesn't allow it... :(
+    #     ## TODO: This can be done much more efficiently without a loop using:
+    #     ## if not np.array_equal(np.sort(slice_), slice_) --> Not increasing
+    #     ## if (np.array(slice_) >= size).any() --> One of the indices is too big
+    #
+    #     c=slice_[i]
+    #     if last >= c:
+    #         raise IndexError('On dimension {0}; indices must be in increasing order and cannot be duplicated: list => {1}'.format(dim, slice_))
+    #     last = c
+    #     if slice_[i] >= size:
+    #         raise IndexError('On dimension {0}; index {1} of list cannot be >= the size: list => {2}, size => {3}'.format(dim, i, slice_, size))
 
 
 def _raise_index_error_slice(slice_, size, dim):


### PR DESCRIPTION
Provides a function (repair_temporal_geometry) to resolve duplicate and out-of-order timesteps.  The values for the other parameters are repaired based on the indexing of the timesteps.

WARNING:  This is a DESTRUCTIVE function!!  The values on disk are read, de-duplicated and reordered based on the values of the temporal_parameter, and then rewritten to disk.  There is NOT a backup made - so there's no way to "undo" this action!!
