### PR TITLE
Fixes mode assumption mismatch with h5py

### DIFF
--- a/coverage_model/hdf_utils.py
+++ b/coverage_model/hdf_utils.py
@@ -89,6 +89,8 @@ class HDFLockingFile(h5py.File):
 
     def __init__(self, name, mode=None, driver=None, 
                  libver=None, userblock_size=None, **kwds):
+        if mode is None:
+            mode = 'r'
         h5py.File.__init__(self, name, mode=mode, driver=driver, libver=libver, 
                 userblock_size=userblock_size, **kwds)
 
@@ -96,6 +98,7 @@ class HDFLockingFile(h5py.File):
 
     def lock(self):
         with self.__rlock:
+
             if self.driver == 'sec2' and self.mode != 'r':
                 if self.filename in self.__locks:
                     raise IOError('[Errno 11] Resource temporarily unavailable')

--- a/coverage_model/test/bricking_assessment_utility.py
+++ b/coverage_model/test/bricking_assessment_utility.py
@@ -92,7 +92,7 @@ class BrickingAssessor(object):
             if not self.use_hdf:
                 arr.fill(-1)
             else:
-                with HDFLockingFile(arr) as f:
+                with HDFLockingFile(arr, mode='a') as f:
                     ds = f.require_dataset(str(i), shape=self.brick_sizes, dtype=self.dtype, chunks=None, fillvalue=-1)
                     ds[:] = -1
 
@@ -161,7 +161,7 @@ class BrickingAssessor(object):
                 self.bricks[bid][brick_slice] = v
             else:
                 fi = self.bricks[bid]
-                with HDFLockingFile(fi) as f:
+                with HDFLockingFile(fi, 'a') as f:
                     ds = f.require_dataset(str(bid), shape=self.brick_sizes, dtype=self.dtype, chunks=None,
                                            fillvalue=-1)
                     ds[brick_slice] = v


### PR DESCRIPTION
The default opening mode is 'r+' which is actually read/write, this patch
changes the default behavior so that when files are opened with no mode
explicitly specified they are opened in read-only without the use of an
exclusion lock.

This patch may cause unforseen issues if readers depend on write privileges;
there is no evidence to suggest that they do.
