### PR TITLE
Removes short-circuit logic for repair_temporal_geometry

### DIFF
--- a/coverage_model/coverage.py
+++ b/coverage_model/coverage.py
@@ -709,10 +709,9 @@ class AbstractCoverage(AbstractIdentifiable):
         num_dups = len(ont) - len(nt)
         if num_dups == 0:  # No duplicates!!
             log.info('The coverage does not have duplicate timesteps')
-            print 'The coverage does not have duplicate timesteps'
-            return
+        else:
+            log.debug('Coverage contains %s duplicate timesteps', num_dups)
 
-        log.debug('Coverage contains %s duplicate timesteps', num_dups)
         # Overwrite all the values, padding num_dups at the end with fill_value
         for p in self.list_parameters():
             vc = self._range_dictionary[p].param_type._value_class

--- a/coverage_model/test/test_complex_coverage.py
+++ b/coverage_model/test/test_complex_coverage.py
@@ -70,6 +70,30 @@ def _make_cov(root_dir, params, nt=10, data_dict=None, make_temporal=True):
 
     return os.path.realpath(scov.persistence_dir)
 
+@attr('UTIL', group='cov')
+class CoverageEnvironment(CoverageModelIntTestCase, CoverageIntTestBase):
+    def test_something(self):
+
+        # Create a large dataset spanning a year
+        # Each coverage represents a week
+    
+
+        cova_pth = _make_cov(self.working_dir, ['value_set'], data_dict={'time': np.arange(0, 20, 2),'value_set' : np.arange(10)})
+        covb_pth = _make_cov(self.working_dir, ['value_set'], data_dict={'time': np.arange(10,30, 2), 'value_set': np.arange(10, 20)})
+
+        cov = SimplexCoverage.load(cova_pth, mode='r+')
+
+        cov_pths = [cova_pth, covb_pth]
+
+
+        ccov = ComplexCoverage(self.working_dir, create_guid(), 'complex coverage', 
+                reference_coverage_locs=cov_pths,
+                parameter_dictionary=ParameterDictionary(),
+                complex_type=ComplexCoverageType.TEMPORAL_AGGREGATION)
+
+        from pyon.util.breakpoint import breakpoint
+        breakpoint(locals(), globals())
+
 
 @attr('INT',group='cov')
 class TestComplexCoverageInt(CoverageModelIntTestCase, CoverageIntTestBase):
@@ -208,28 +232,6 @@ class TestComplexCoverageInt(CoverageModelIntTestCase, CoverageIntTestBase):
     # Additional tests specific to Complex Coverage
     ######################
 
-    @unittest.skip('UTIL')
-    def test_something(self):
-
-        # Create a large dataset spanning a year
-        # Each coverage represents a week
-    
-
-        cova_pth = _make_cov(self.working_dir, ['value_set'], data_dict={'time': np.arange(10),'value_set' : np.arange(10)})
-        covb_pth = _make_cov(self.working_dir, ['value_set'], data_dict={'time': np.arange(20,30), 'value_set': np.arange(10)})
-
-        cov = SimplexCoverage.load(cova_pth, mode='r+')
-
-        cov_pths = [cova_pth, covb_pth]
-
-
-        ccov = ComplexCoverage(self.working_dir, create_guid(), 'complex coverage', 
-                reference_coverage_locs=cov_pths,
-                parameter_dictionary=ParameterDictionary(),
-                complex_type=ComplexCoverageType.TEMPORAL_AGGREGATION)
-
-        from pyon.util.breakpoint import breakpoint
-        breakpoint(locals(), globals())
 
 
 


### PR DESCRIPTION
repair_temporal_geometry would short-circuit itself if there were no duplicates,
this commit patches the short-circuit so that the entire function logic
executes, regardless of duplicates.
