### PR TITLE
Adds initial support for better retrieving

### DIFF
--- a/coverage_model/coverage.py
+++ b/coverage_model/coverage.py
@@ -1277,7 +1277,7 @@ class ComplexCoverage(AbstractCoverage):
             raise TypeError("A Timeseries ComplexCoverage doesn't support "
                             "get_parameter_values, please use "
                             "get_timeseries_values")
-        return AbstractCoverage.get_parameter_values(self, param_name, tdoa=None, sdoa=None, return_value=None)
+        return AbstractCoverage.get_parameter_values(self, param_name, tdoa=tdoa, sdoa=sdoa, return_value=return_value)
 
     def get_timeseries_values(self, tdoa=None, param_list=None, raw=False,
             unsorted=False):

--- a/coverage_model/coverage.py
+++ b/coverage_model/coverage.py
@@ -456,7 +456,7 @@ class AbstractCoverage(AbstractIdentifiable):
 
         stride = None
         if isinstance(temporal_slice, slice):
-            start, stop = temporal_slice.start, temporal_slice.stop
+            start, stop, stride = temporal_slice.start, temporal_slice.stop, temporal_slice.step
         elif isinstance(temporal_slice, tuple):
             if len(temporal_slice) == 2:
                 start, stop = temporal_slice

--- a/coverage_model/coverage.py
+++ b/coverage_model/coverage.py
@@ -709,10 +709,9 @@ class AbstractCoverage(AbstractIdentifiable):
         num_dups = len(ont) - len(nt)
         if num_dups == 0:  # No duplicates!!
             log.info('The coverage does not have duplicate timesteps')
-            print 'The coverage does not have duplicate timesteps'
-            return
+        else:
+            log.debug('Coverage contains %s duplicate timesteps', num_dups)
 
-        log.debug('Coverage contains %s duplicate timesteps', num_dups)
         # Overwrite all the values, padding num_dups at the end with fill_value
         for p in self.list_parameters():
             vc = self._range_dictionary[p].param_type._value_class

--- a/coverage_model/test/coverage_test_base.py
+++ b/coverage_model/test/coverage_test_base.py
@@ -672,6 +672,43 @@ class CoverageIntTestBase(object):
             results.append(np.array_equiv(mock_data, data))
         self.assertTrue(False not in results)
 
+    def test_get_value_dict(self):
+        brick_size = 10
+        time_steps = 30
+        cov, cov_name = self.get_cov(brick_size=brick_size, nt=time_steps)
+        vdict = cov.get_value_dictionary()
+        for p in cov.list_parameters():
+            self.assertIn(p, vdict)
+
+        if cov.num_timesteps:
+            self.assertEquals(len(vdict['time']), 30)
+            np.testing.assert_array_equal(vdict['time'], np.arange(30))
+        else:
+            self.assertEquals(len(vdict['time']), 0)
+            np.testing.assert_array_equal(vdict['time'], np.array([]))
+
+    def test_get_value_dict_tslice(self):
+        brick_size = 10
+        time_steps = 30
+        cov, cov_name = self.get_cov(brick_size=brick_size, nt=time_steps)
+        if cov.num_timesteps:
+            cov.set_parameter_values('time', np.arange(30) + 20)
+        vdict = cov.get_value_dictionary(temporal_slice=(25, 30))
+        for p in cov.list_parameters():
+            self.assertIn(p, vdict)
+            if cov.num_timesteps:
+                self.assertEquals(len(vdict[p]), 5)
+            else:
+                self.assertEquals(len(vdict[p]), 0)
+
+        if cov.num_timesteps:
+            np.testing.assert_array_equal(vdict['time'], np.arange(25,30))
+        else:
+            np.testing.assert_array_equal(vdict['time'], np.array([]))
+
+
+
+
     
     # ############################
     # SET

--- a/coverage_model/test/test_complex_coverage.py
+++ b/coverage_model/test/test_complex_coverage.py
@@ -78,36 +78,22 @@ class CoverageEnvironment(CoverageModelIntTestCase, CoverageIntTestBase):
         # Each coverage represents a week
     
 
-        cova_pth = _make_cov(self.working_dir, ['value_set'], data_dict={'time': np.arange(0, 20, 2),'value_set' : np.arange(10)})
-        covb_pth = _make_cov(self.working_dir, ['value_set'], data_dict={'time': np.arange(10,30, 2), 'value_set': np.arange(10, 20)})
-        covc_pth = _make_cov(self.working_dir, ['value_set'], data_dict={'time': np.arange(5,15, 1), 'value_set': np.arange(20, 30)})
+        cova_pth = _make_cov(self.working_dir, ['value_set'], data_dict={'time': np.arange(0, 10),'value_set':np.arange(10)})
+        covb_pth = _make_cov(self.working_dir, ['value_set'], data_dict={'time': np.arange(10, 20),'value_set':np.arange(10)})
 
-        cov = SimplexCoverage.load(cova_pth, mode='r+')
-
-        cov_pths = [cova_pth, covb_pth, covc_pth]
+        cov_pths = [cova_pth, covb_pth]
 
 
-        ccov = ComplexCoverage(self.working_dir, create_guid(), 'complex coverage', 
-                reference_coverage_locs=cov_pths,
-                parameter_dictionary=ParameterDictionary(),
-                complex_type=ComplexCoverageType.TEMPORAL_AGGREGATION)
-        
-        with self.assertRaises(TypeError):
-            ccov.insert_value_set({'time':np.arange(10)})
 
         ccov = ComplexCoverage(self.working_dir, create_guid(), 'complex coverage', 
                 reference_coverage_locs=cov_pths,
                 parameter_dictionary=ParameterDictionary(),
                 complex_type=ComplexCoverageType.TIMESERIES)
 
-        with self.assertRaises(ValueError):
-            # Raises error because there's no temporal domain
-            ccov.insert_value_set({'temp': np.arange(20)})
 
-        with self.assertRaises(ValueError):
-            # Raises error because of improper shape
-            ccov.insert_value_set({'time':np.arange(10), 'temp':np.arange(20)})
-
+        t = range(20,30)
+        t.reverse()
+        ccov.insert_value_set({'time' : np.array(t), 'temp':np.arange(10)})
 
         from pyon.util.breakpoint import breakpoint
         breakpoint(locals(), globals())

--- a/coverage_model/test/test_complex_coverage.py
+++ b/coverage_model/test/test_complex_coverage.py
@@ -18,6 +18,7 @@ import unittest
 from copy import deepcopy
 
 from coverage_test_base import CoverageIntTestBase, get_props
+import time
 
 
 def _make_cov(root_dir, params, nt=10, data_dict=None, make_temporal=True):
@@ -85,15 +86,18 @@ class CoverageEnvironment(CoverageModelIntTestCase, CoverageIntTestBase):
 
 
 
+
         ccov = ComplexCoverage(self.working_dir, create_guid(), 'complex coverage', 
                 reference_coverage_locs=cov_pths,
                 parameter_dictionary=ParameterDictionary(),
                 complex_type=ComplexCoverageType.TIMESERIES)
 
 
-        t = range(20,30)
+
+        t = range(15,25)
         t.reverse()
-        ccov.insert_value_set({'time' : np.array(t), 'temp':np.arange(10)})
+        ccov.insert_value_set({'time' : np.array(t), 'value_set':np.arange(10)})
+
 
         from pyon.util.breakpoint import breakpoint
         breakpoint(locals(), globals())

--- a/coverage_model/test/test_complex_coverage.py
+++ b/coverage_model/test/test_complex_coverage.py
@@ -70,6 +70,30 @@ def _make_cov(root_dir, params, nt=10, data_dict=None, make_temporal=True):
 
     return os.path.realpath(scov.persistence_dir)
 
+@attr('UTIL', group='cov')
+class CoverageEnvironment(CoverageModelIntTestCase, CoverageIntTestBase):
+    def test_something(self):
+
+        # Create a large dataset spanning a year
+        # Each coverage represents a week
+    
+
+        cova_pth = _make_cov(self.working_dir, ['value_set'], data_dict={'time': np.arange(0, 20, 2),'value_set' : np.arange(10)})
+        covb_pth = _make_cov(self.working_dir, ['value_set'], data_dict={'time': np.arange(10,30, 2), 'value_set': np.arange(10, 20)})
+
+        cov = SimplexCoverage.load(cova_pth, mode='r+')
+
+        cov_pths = [cova_pth, covb_pth]
+
+
+        ccov = ComplexCoverage(self.working_dir, create_guid(), 'complex coverage', 
+                reference_coverage_locs=cov_pths,
+                parameter_dictionary=ParameterDictionary(),
+                complex_type=ComplexCoverageType.TEMPORAL_AGGREGATION)
+
+        from pyon.util.breakpoint import breakpoint
+        breakpoint(locals(), globals())
+
 
 @attr('INT',group='cov')
 class TestComplexCoverageInt(CoverageModelIntTestCase, CoverageIntTestBase):
@@ -208,28 +232,6 @@ class TestComplexCoverageInt(CoverageModelIntTestCase, CoverageIntTestBase):
     # Additional tests specific to Complex Coverage
     ######################
 
-    @unittest.skip('UTIL')
-    def test_something(self):
-
-        # Create a large dataset spanning a year
-        # Each coverage represents a week
-    
-
-        cova_pth = _make_cov(self.working_dir, ['value_set'], data_dict={'time': np.arange(10),'value_set' : np.arange(10)})
-        covb_pth = _make_cov(self.working_dir, ['value_set'], data_dict={'time': np.arange(20,30), 'value_set': np.arange(10)})
-
-        cov = SimplexCoverage.load(cova_pth, mode='r+')
-
-        cov_pths = [cova_pth, covb_pth]
-
-
-        ccov = ComplexCoverage(self.working_dir, create_guid(), 'complex coverage', 
-                reference_coverage_locs=cov_pths,
-                parameter_dictionary=ParameterDictionary(),
-                complex_type=ComplexCoverageType.TEMPORAL_AGGREGATION)
-
-        from pyon.util.breakpoint import breakpoint
-        breakpoint(locals(), globals())
 
 
 

--- a/coverage_model/test/test_complex_coverage.py
+++ b/coverage_model/test/test_complex_coverage.py
@@ -108,9 +108,10 @@ class CoverageEnvironment(CoverageModelIntTestCase, CoverageIntTestBase):
 
         ccov.insert_value_set({'time' : np.arange(40,45), 'value_set' : np.ones(5) * 8})
         
-
         from pyon.util.breakpoint import breakpoint
         breakpoint(locals(), globals())
+        vcov = ViewCoverage(self.working_dir, create_guid(), 'view coverage', reference_coverage_location = ccov.persistence_dir)
+
 
     @attr('UTIL')
     def test_aggregates(self):
@@ -130,6 +131,9 @@ class CoverageEnvironment(CoverageModelIntTestCase, CoverageIntTestBase):
 
         ccov.append_reference_coverage(cova_pth)
         ccov.append_reference_coverage(covc_pth)
+
+        vcov = ViewCoverage(self.working_dir, create_guid(), 'view coverage', reference_coverage_location = ccov.persistence_dir)
+
         
         from pyon.util.breakpoint import breakpoint
         breakpoint(locals(), globals())

--- a/coverage_model/test/test_complex_coverage.py
+++ b/coverage_model/test/test_complex_coverage.py
@@ -71,6 +71,7 @@ def _make_cov(root_dir, params, nt=10, data_dict=None, make_temporal=True):
 
     return os.path.realpath(scov.persistence_dir)
 
+@unittest.skip("UTIL only")
 @attr('UTIL', group='cov')
 class CoverageEnvironment(CoverageModelIntTestCase, CoverageIntTestBase):
     def test_something(self):

--- a/coverage_model/test/test_complex_coverage.py
+++ b/coverage_model/test/test_complex_coverage.py
@@ -80,16 +80,34 @@ class CoverageEnvironment(CoverageModelIntTestCase, CoverageIntTestBase):
 
         cova_pth = _make_cov(self.working_dir, ['value_set'], data_dict={'time': np.arange(0, 20, 2),'value_set' : np.arange(10)})
         covb_pth = _make_cov(self.working_dir, ['value_set'], data_dict={'time': np.arange(10,30, 2), 'value_set': np.arange(10, 20)})
+        covc_pth = _make_cov(self.working_dir, ['value_set'], data_dict={'time': np.arange(5,15, 1), 'value_set': np.arange(20, 30)})
 
         cov = SimplexCoverage.load(cova_pth, mode='r+')
 
-        cov_pths = [cova_pth, covb_pth]
+        cov_pths = [cova_pth, covb_pth, covc_pth]
 
 
         ccov = ComplexCoverage(self.working_dir, create_guid(), 'complex coverage', 
                 reference_coverage_locs=cov_pths,
                 parameter_dictionary=ParameterDictionary(),
                 complex_type=ComplexCoverageType.TEMPORAL_AGGREGATION)
+        
+        with self.assertRaises(TypeError):
+            ccov.insert_value_set({'time':np.arange(10)})
+
+        ccov = ComplexCoverage(self.working_dir, create_guid(), 'complex coverage', 
+                reference_coverage_locs=cov_pths,
+                parameter_dictionary=ParameterDictionary(),
+                complex_type=ComplexCoverageType.TIMESERIES)
+
+        with self.assertRaises(ValueError):
+            # Raises error because there's no temporal domain
+            ccov.insert_value_set({'temp': np.arange(20)})
+
+        with self.assertRaises(ValueError):
+            # Raises error because of improper shape
+            ccov.insert_value_set({'time':np.arange(10), 'temp':np.arange(20)})
+
 
         from pyon.util.breakpoint import breakpoint
         breakpoint(locals(), globals())
@@ -729,3 +747,37 @@ class TestComplexCoverageInt(CoverageModelIntTestCase, CoverageIntTestBase):
 
         # Ensure the correct path is returned from ComplexCoverage.head_coverage_path in CC --> [SC & CC --> [VC & SC]] scenario
         self.assertEqual(comp_cov3.head_coverage_path, covb_pth)
+
+    def test_timeseries_inserts(self):
+
+
+        cova_pth = _make_cov(self.working_dir, ['value_set'], data_dict={'time': np.arange(0, 20, 2),'value_set' : np.arange(10)})
+        covb_pth = _make_cov(self.working_dir, ['value_set'], data_dict={'time': np.arange(10,30, 2), 'value_set': np.arange(10, 20)})
+        covc_pth = _make_cov(self.working_dir, ['value_set'], data_dict={'time': np.arange(5,15, 1), 'value_set': np.arange(20, 30)})
+
+        #cov = SimplexCoverage.load(cova_pth, mode='r+')
+
+        cov_pths = [cova_pth, covb_pth, covc_pth]
+
+
+        ccov = ComplexCoverage(self.working_dir, create_guid(), 'complex coverage', 
+                reference_coverage_locs=cov_pths,
+                parameter_dictionary=ParameterDictionary(),
+                complex_type=ComplexCoverageType.TEMPORAL_AGGREGATION)
+        
+        with self.assertRaises(TypeError):
+            ccov.insert_value_set({'time':np.arange(10)})
+
+        ccov = ComplexCoverage(self.working_dir, create_guid(), 'complex coverage', 
+                reference_coverage_locs=cov_pths,
+                parameter_dictionary=ParameterDictionary(),
+                complex_type=ComplexCoverageType.TIMESERIES)
+
+        with self.assertRaises(ValueError):
+            # Raises error because there's no temporal domain
+            ccov.insert_value_set({'temp': np.arange(20)})
+
+        with self.assertRaises(ValueError):
+            # Raises error because of improper shape
+            ccov.insert_value_set({'time':np.arange(10), 'temp':np.arange(20)})
+

--- a/coverage_model/test/test_view_coverage.py
+++ b/coverage_model/test/test_view_coverage.py
@@ -269,3 +269,8 @@ class TestSampleCovViewInt(CoverageModelIntTestCase, CoverageIntTestBase):
     @unittest.skip('Does not apply to ViewCoverage.')
     def test_coverage_mode_set_value(self):
         pass
+
+    @unittest.skip('Does not apply to ViewCoverage.')
+    def test_get_value_dict_tslice(self):
+        pass
+

--- a/coverage_model/utils.py
+++ b/coverage_model/utils.py
@@ -327,3 +327,8 @@ class Interval:
             return True
         return False
 
+    def union(self, other):
+        x0 = min(self.x0, other.x0)
+        x1 = max(self.x1, other.x1)
+        return Interval(x0,x1)
+

--- a/coverage_model/utils.py
+++ b/coverage_model/utils.py
@@ -283,3 +283,47 @@ def express_slice(slice_, total_shape):
 
 def get_random_sample(length, min, max):
     return np.random.random_sample(length) * (max - min) + min
+
+class Interval:
+    '''
+    A class that represents a 1-d interval
+    See: http://bit.ly/15TNgiH
+    '''
+    def __init__(self, x0, x1, left=None, right=None):
+        assert x0 <= x1
+        self.x0 = x0
+        self.x1 = x1
+        self.left = left
+        self.right = right
+
+    def __repr__(self):
+        retval =  '(%s,%s)' % (self.x0, self.x1)
+        if self.left or self.right:
+            retval += "'"
+        return retval
+
+
+    def __cmp__(self, other):
+        if self.x0 < other.x0:
+            return -1
+        elif self.x0 > other.x0:
+            return 1
+        else: # self.x0 == other.x0:
+            if self.x1 > other.x1:
+                return -1
+            elif self.x1 < other.x1:
+                return 1
+        return 0
+
+    def contains(self, other):
+        return self.x0 <= other.x0 and self.x1 >= other.x1
+
+    def intersects(self, other):
+        if other.x0 <= self.x0 and self.x0 <= other.x1:
+            return True
+        if other.x0 <= self.x1 and self.x1 <= other.x1:
+            return True
+        if self.x1 <= other.x0 and other.x1 <= self.x1:
+            return True
+        return False
+

--- a/coverage_model/utils.py
+++ b/coverage_model/utils.py
@@ -337,3 +337,5 @@ class Interval:
         x1 = max(self.x1, other.x1)
         return Interval(x0,x1)
 
+    def to_tuple(self):
+        return (self.x0, self.x1)

--- a/coverage_model/utils.py
+++ b/coverage_model/utils.py
@@ -290,6 +290,10 @@ class Interval:
     See: http://bit.ly/15TNgiH
     '''
     def __init__(self, x0, x1, left=None, right=None):
+        if x0 is None:
+            x0 = -np.inf
+        if x1 is None:
+            x1 = np.inf
         assert x0 <= x1
         self.x0 = x0
         self.x1 = x1
@@ -318,14 +322,15 @@ class Interval:
     def contains(self, other):
         return self.x0 <= other.x0 and self.x1 >= other.x1
 
-    def intersects(self, other):
-        if other.x0 <= self.x0 and self.x0 <= other.x1:
+    def disjoint(self, other):
+        if self.x0 > other.x1:
             return True
-        if other.x0 <= self.x1 and self.x1 <= other.x1:
-            return True
-        if self.x1 <= other.x0 and other.x1 <= self.x1:
+        if self.x1 < other.x0:
             return True
         return False
+
+    def intersects(self, other):
+        return not self.disjoint(other)
 
     def union(self, other):
         x0 = min(self.x0, other.x0)


### PR DESCRIPTION
All the changes are purely additive and should not affect any existing function.

Adds a new Complex Coverage type: TIMESERIES
TIMESERIES has the ability to do random inserts and random reads with good performance.

Adds a new function to all coverage models: `get_value_dictionary`
Behaves just like `get_parameter_values` except that it returns a dictionary of values, it can slice on the temporal values as well as slice on the domain values and it doesn't require the entire temporal domain to verify slices. A huge improvement for retrieval operations, now we won't have to look at the entire "time" array every time we make a retrieve operation. 

The value dictionaries are sorted IF any subset of the coverages overlap, and duplicates are removed.

Part of [OOIION-1310](https://jira.oceanobservatories.org/tasks/browse/OOIION-1310)

[Covmodel_test](http://buildbot.oceanobservatories.org:8010/builders/covmodel_test/builds/144)
