### PR TITLE
OOIION-1310 Coverage doesn't "natively" support out-of-order data delivery or duplicate data records

### DIFF
--- a/coverage_model/coverage.py
+++ b/coverage_model/coverage.py
@@ -44,8 +44,10 @@ from persistence_helpers import get_coverage_type
 from coverage_model import utils
 from coverage_model.utils import Interval
 from copy import deepcopy
+from pyon.util.breakpoint import time_profile
 import numpy as np
 import numexpr as ne
+import time
 import os, collections, pickle
 
 #=========================
@@ -480,10 +482,13 @@ class AbstractCoverage(AbstractIdentifiable):
         # time-array to find out where start and stop are, we just use a
         # binary-search on an "array-like" HDF5 interface
 
-        start_idx = np.searchsorted(time_vector, start)
-        stop_idx = np.searchsorted(time_vector, stop)
+        start_idx = self._searchsorted(time_vector, start)
+        stop_idx = self._searchsorted(time_vector, stop)
         slice_ = slice(start_idx, stop_idx, stride)
         return slice_
+
+    def _searchsorted(self, time_vector, val):
+        return np.searchsorted(time_vector[:], val)
 
 
     def _aggregate_value_dict(self, value_dict, slice_, param_list=None):


### PR DESCRIPTION
Binary Search over HDF5 API is too slow

So reading Log N times is WAY slower than reading the entire dataset once and
doing the binary search in memory. The dataset would need to be more than 5
years long before memory would start being a concern here. Binary search is
still the best way to identify the indexes which is better than checking every
single value but downloading the entire array into memory is the tradeoff,
which was our previous approach. This patch is the fastest combination of both
approaches.

Part of [OOIION-1310](https://jira.oceanobservatories.org/tasks/browse/OOIION-1310)
