### PR TITLE
OOIION-1497 HDF File Locking Cache R2

### DIFF
--- a/coverage_model/hdf_utils.py
+++ b/coverage_model/hdf_utils.py
@@ -114,6 +114,7 @@ class HDFLockingFile(h5py.File):
                 try:
                     fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
                 except IOError:
+                    del self.__locks[self.filename] # Eject it from the cache, the filesystem has it
                     log.exception('Locking Error on %s', self.filename)
                     raise
 

--- a/coverage_model/hdf_utils.py
+++ b/coverage_model/hdf_utils.py
@@ -101,6 +101,8 @@ class HDFLockingFile(h5py.File):
         with self.__rlock:
 
             if self.driver == 'sec2' and self.mode != 'r':
+                # Have to use a cache because the if the flock call comes from the same pid, it will be ignored instead 
+                # of setting errno
                 if self.filename in self.__locks:
                     raise IOError('[Errno 11] Resource temporarily unavailable, cached lock on %s' % self.filename)
 


### PR DESCRIPTION
This pull request fixes the cache invalidation strategy by the HDF Locking utility. 

Before, if the filesystem had a legitimate lock in-place and a client attempted to acquire the lock, it would make an entry in the cache that it was locked, any subsequent calls to try to lock it would fail because it was cached and there was no invalidation of the cache. 

This change ensures that if the filesystem indicates that the file is locked, then the cache is invalidated. 

This pull request also contains a test to verify that this functionality does in-fact work.
