### PR TITLE
CIDEVSTC-278 Adds egg-management to parameter functions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,7 @@ setup(  name = 'coverage-model',
         'networkx==1.7',
         'pyparsing==1.5.6',
         'msgpack-python==0.1.13',
+        'requests', # It should be hardcoded to a version imho but it's not in pyon
 #        'scipy==0.10.1',
     ],
 )


### PR DESCRIPTION
[CIDEVSTC-278](https://jira.oceanobservatories.org/tasks/browse/CIDEVSTC-278)

It's mirrored from that in TransformWorker. Because a coverage's parameter function may be run on any client that loads the coverage, we have to add egg-support at the coverage model layer.
