### PR TITLE
TEST - Removes broken test from run cycle

### DIFF
--- a/coverage_model/test/test_complex_coverage.py
+++ b/coverage_model/test/test_complex_coverage.py
@@ -73,7 +73,7 @@ def _make_cov(root_dir, params, nt=10, data_dict=None, make_temporal=True):
     return os.path.realpath(scov.persistence_dir)
 
 class CoverageEnvironment(CoverageModelIntTestCase, CoverageIntTestBase):
-    @attr('INT', group='cov')
+    @attr('UTIL', group='cov')
     def test_cov_params(self):
         contexts = create_all_params()
         del contexts['time']


### PR DESCRIPTION
The coverage model build doesn't have ion-functions as a dependency
so it can't import any modules from it. The test will run successfully
on coi-services though.
