### PR TITLE
CIDEVSTC-291 - Coverage Projection 

### DIFF
--- a/coverage_model/coverage.py
+++ b/coverage_model/coverage.py
@@ -317,6 +317,7 @@ class AbstractCoverage(AbstractIdentifiable):
         if hasattr(pcontext, '_pval_callback'):
             pcontext._pval_callback = self.get_parameter_values
             pcontext._pctxt_callback = self.get_parameter_context
+            pcontext._pdir = self.persistence_dir
 
         self._range_dictionary.add_context(pcontext)
         s = self._persistence_layer.init_parameter(pcontext, self._bricking_scheme)
@@ -2186,6 +2187,8 @@ class SimplexCoverage(AbstractCoverage):
                     if hasattr(pc, '_pval_callback'):
                         pc._pval_callback = self.get_parameter_values
                         pc._pctxt_callback = self.get_parameter_context
+                        pc._pdir = self.persistence_dir
+
                     self._range_dictionary.add_context(pc)
                     if pc.param_type._value_class == 'SparseConstantValue':
                         s = SparsePersistedStorage(md, mm, self._persistence_layer.brick_dispatcher, dtype=pc.param_type.storage_encoding, fill_value=pc.param_type.fill_value, mode=self.mode, inline_data_writes=inline_data_writes, auto_flush=auto_flush_values)

--- a/coverage_model/parameter_functions.py
+++ b/coverage_model/parameter_functions.py
@@ -14,6 +14,7 @@ import numexpr as ne
 from numbers import Number
 from collections import OrderedDict
 from coverage_model.basic_types import AbstractBase
+import os
 
 
 class ParameterFunctionException(Exception):
@@ -269,3 +270,20 @@ class NumexprFunction(AbstractFunction):
             ret = self.expression == other.expression
 
         return ret
+
+class ExternalFunction(AbstractFunction):
+    def __init__(self, name, external_guid, external_name):
+        self.external_name = external_name
+        param_map = {external_name : external_guid}
+        AbstractFunction.__init__(self, name, [], param_map)
+
+
+    def evaluate(self, pval_callback, pdir, slice_, fill_value=-9999):
+        from coverage_model.coverage import AbstractCoverage
+        root_path, guid = os.path.split(pdir)
+        external_guid = self.param_map[self.external_name]
+        path = os.path.join(root_path, external_guid)
+        cov = AbstractCoverage.load(path)
+        return cov.get_parameter_values(self.external_name, slice_)
+
+

--- a/coverage_model/parameter_types.py
+++ b/coverage_model/parameter_types.py
@@ -591,6 +591,7 @@ class ParameterFunctionType(AbstractSimplexParameterType):
 
         self._template_attrs['_pval_callback'] = None
         self._template_attrs['_pctxt_callback'] = None
+        self._template_attrs['_pdir'] = None
 
         self._gen_template_attrs()
 
@@ -607,13 +608,14 @@ class ParameterFunctionType(AbstractSimplexParameterType):
 
     def _todict(self, exclude=None):
         # Must exclude _cov_range_value from persistence
-        return super(ParameterFunctionType, self)._todict(exclude=['_pval_callback', '_pctxt_callback', '_fmap', '_iparams', '_dparams'])
+        return super(ParameterFunctionType, self)._todict(exclude=['_pdir', '_pval_callback', '_pctxt_callback', '_fmap', '_iparams', '_dparams'])
 
     @classmethod
     def _fromdict(cls, cmdict, arg_masks=None):
         ret = super(ParameterFunctionType, cls)._fromdict(cmdict, arg_masks=arg_masks)
         # Add the _pval_callback attribute, initialized to None
         ret._pval_callback = None
+        ret._pdir = None
         return ret
 
     def __eq__(self, other):

--- a/coverage_model/test/test_complex_coverage.py
+++ b/coverage_model/test/test_complex_coverage.py
@@ -18,6 +18,7 @@ import unittest
 from copy import deepcopy
 from coverage_model.hdf_utils import HDFLockingFile
 from coverage_test_base import CoverageIntTestBase, get_props
+from coverage_model.parameter_functions import ExternalFunction
 import time
 
 
@@ -167,6 +168,23 @@ class CoverageEnvironment(CoverageModelIntTestCase, CoverageIntTestBase):
         ccov.append_reference_coverage(covc_pth)
 
         vcov = ViewCoverage(self.working_dir, create_guid(), 'view coverage', reference_coverage_location = ccov.persistence_dir)
+
+    @attr('UTIL', group='cov')
+    def test_external_refs(self):
+
+        offset = NumexprFunction('offset', arg_list=['x'], expression='x + 1')
+        offset.param_map = {'x':'value_set'}
+        ctx = ParameterContext('offset', param_type=ParameterFunctionType(offset, value_encoding='<f4'))
+
+        cova_pth = _make_cov(self.working_dir, ['value_set', ctx], data_dict={'time':np.arange(10), 'value_set':np.arange(20,30)})
+        cova = SimplexCoverage.load(cova_pth, mode='r')
+        pfunc = ExternalFunction('example', cova.persistence_guid, 'offset')
+        ctx = ParameterContext('example', param_type=ParameterFunctionType(pfunc, value_encoding='<f4'))
+        covb_pth = _make_cov(self.working_dir, [ctx], data_dict={'time':np.arange(10)})
+        cov = SimplexCoverage.load(covb_pth, mode='r')
+        from pyon.util.breakpoint import breakpoint
+        breakpoint(locals(), globals())
+        
 
         
 

--- a/coverage_model/test/test_complex_coverage.py
+++ b/coverage_model/test/test_complex_coverage.py
@@ -169,22 +169,26 @@ class CoverageEnvironment(CoverageModelIntTestCase, CoverageIntTestBase):
 
         vcov = ViewCoverage(self.working_dir, create_guid(), 'view coverage', reference_coverage_location = ccov.persistence_dir)
 
-    @attr('UTIL', group='cov')
+    @attr('INT', group='cov')
     def test_external_refs(self):
 
+        # Create a three param coverage
         offset = NumexprFunction('offset', arg_list=['x'], expression='x + 1')
         offset.param_map = {'x':'value_set'}
         ctx = ParameterContext('offset', param_type=ParameterFunctionType(offset, value_encoding='<f4'))
 
         cova_pth = _make_cov(self.working_dir, ['value_set', ctx], data_dict={'time':np.arange(10), 'value_set':np.arange(20,30)})
         cova = SimplexCoverage.load(cova_pth, mode='r')
+
+
+        # Create another coverage that references the above
         pfunc = ExternalFunction('example', cova.persistence_guid, 'offset')
         ctx = ParameterContext('example', param_type=ParameterFunctionType(pfunc, value_encoding='<f4'))
-        covb_pth = _make_cov(self.working_dir, [ctx], data_dict={'time':np.arange(10)})
+        covb_pth = _make_cov(self.working_dir, [ctx], data_dict={'time':np.arange(0.5, 10.5, 1)})
         cov = SimplexCoverage.load(covb_pth, mode='r')
-        from pyon.util.breakpoint import breakpoint
-        breakpoint(locals(), globals())
-        
+        # Assert that the values are correctly interpolated 
+        np.testing.assert_array_equal(cov.get_parameter_values('example'), np.arange(21.5, 31.5, 1))
+
 
         
 


### PR DESCRIPTION
Adds the ability to reference external coverages. 

Necessary for:
- Colocated instrument in data processing
- Geospatial information from platform onto instrument.
